### PR TITLE
feat: add optional file support for config merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Optional File Support
+- **Optional files in config merging** - Specify files that can be missing without causing errors
+  - `FileSpec.required(path)` - File must exist (error if missing)
+  - `FileSpec.optional(path)` - File is silently skipped if missing
+  - `Config.load_merged_with_specs([...])` - Load with mixed required/optional files
+  - `Config.optional(path)` - Convenience method to merge a single optional file
+- Common use case: local developer overrides that aren't committed to version control
+
 #### Source Tracking
 - **File-level source tracking** for merged configurations - track which file each value came from
   - `config.get_source("path.to.value")` - Returns the filename that provided this value
@@ -47,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added acceptance tests for file resolver encoding (3 tests)
 - Added acceptance test for sensitivity inheritance via self-references
 - Re-enabled previously disabled circular reference acceptance tests (2 tests)
+- Added acceptance tests for optional file support (10 tests covering missing files, merge behavior, deep merge)
 
 ## [0.1.3] - 2026-01-09
 

--- a/crates/holoconf-cli/src/cli.rs
+++ b/crates/holoconf-cli/src/cli.rs
@@ -387,7 +387,7 @@ fn cmd_get(
                         holoconf_core::Value::Null => println!("null"),
                         holoconf_core::Value::Bytes(bytes) => {
                             // For bytes, output as base64
-                            use base64::{Engine as _, engine::general_purpose::STANDARD};
+                            use base64::{engine::general_purpose::STANDARD, Engine as _};
                             println!("{}", STANDARD.encode(bytes));
                         }
                         _ => {
@@ -489,7 +489,11 @@ fn cmd_schema_template(file: PathBuf, output: Option<PathBuf>) -> ExitCode {
             eprintln!("{}: {}", "Error writing file".red(), e);
             return ExitCode::from(2);
         }
-        eprintln!("{} Wrote template to {}", "✓".green(), output_path.display());
+        eprintln!(
+            "{} Wrote template to {}",
+            "✓".green(),
+            output_path.display()
+        );
     } else {
         print!("{}", template);
     }
@@ -530,4 +534,3 @@ fn cmd_schema_docs(file: PathBuf, format: &str) -> ExitCode {
         }
     }
 }
-

--- a/crates/holoconf-core/src/error.rs
+++ b/crates/holoconf-core/src/error.rs
@@ -232,7 +232,10 @@ impl Error {
             }),
             path: None,
             source_location: None,
-            help: Some(format!("Check the '{}' resolver implementation", resolver_name)),
+            help: Some(format!(
+                "Check the '{}' resolver implementation",
+                resolver_name
+            )),
             cause: None,
         }
     }

--- a/crates/holoconf-core/src/lib.rs
+++ b/crates/holoconf-core/src/lib.rs
@@ -26,7 +26,7 @@ pub mod value;
 
 mod config;
 
-pub use config::{Config, ConfigOptions};
+pub use config::{Config, ConfigOptions, FileSpec};
 pub use error::{Error, Result};
 pub use resolver::{ResolvedValue, Resolver, ResolverRegistry};
 pub use schema::Schema;

--- a/crates/holoconf-core/src/resolver.rs
+++ b/crates/holoconf-core/src/resolver.rs
@@ -336,7 +336,10 @@ fn file_resolver(
 
     let file_path_str = &args[0];
     let parse_mode = kwargs.get("parse").map(|s| s.as_str()).unwrap_or("auto");
-    let encoding = kwargs.get("encoding").map(|s| s.as_str()).unwrap_or("utf-8");
+    let encoding = kwargs
+        .get("encoding")
+        .map(|s| s.as_str())
+        .unwrap_or("utf-8");
 
     // Resolve relative paths based on context base path
     let file_path = if Path::new(file_path_str).is_relative() {
@@ -360,7 +363,7 @@ fn file_resolver(
     let content = match encoding {
         "base64" => {
             // Read as binary and base64 encode
-            use base64::{Engine as _, engine::general_purpose::STANDARD};
+            use base64::{engine::general_purpose::STANDARD, Engine as _};
             let bytes = std::fs::read(&file_path)
                 .map_err(|_| Error::file_not_found(file_path_str, Some(ctx.config_path.clone())))?;
             STANDARD.encode(bytes)
@@ -1020,7 +1023,7 @@ mod tests {
         let content = result.value.as_str().unwrap();
 
         // Verify the base64 encoding is correct
-        use base64::{Engine as _, engine::general_purpose::STANDARD};
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
         let expected = STANDARD.encode(b"Hello\x00\x01\x02World");
         assert_eq!(content, expected);
 

--- a/crates/holoconf-core/src/value.rs
+++ b/crates/holoconf-core/src/value.rs
@@ -4,7 +4,7 @@
 //! Values can be scalars (string, int, float, bool, null, bytes),
 //! sequences (arrays), or mappings (objects).
 
-use base64::{Engine as _, engine::general_purpose::STANDARD};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -475,7 +475,9 @@ fn remove_sources_with_prefix(
     }
     // Remove exact match and any children (prefix. or prefix[)
     sources.retain(|path, _| {
-        path != prefix && !path.starts_with(&format!("{}.", prefix)) && !path.starts_with(&format!("{}[", prefix))
+        path != prefix
+            && !path.starts_with(&format!("{}.", prefix))
+            && !path.starts_with(&format!("{}[", prefix))
     });
 }
 

--- a/docs/guide/merging.md
+++ b/docs/guide/merging.md
@@ -129,4 +129,94 @@ config/
     }
     ```
 
+## Optional Files
+
+Sometimes you want to load configuration files that may or may not exist. For example, a `local.yaml` file that developers can create for local overrides but isn't committed to version control.
+
+Use `FileSpec` to specify which files are required and which are optional:
+
+=== "Python"
+
+    ```python
+    from holoconf import Config, FileSpec
+
+    # Load with optional files - missing optional files are silently skipped
+    config = Config.load_merged_with_specs([
+        FileSpec.required("config/base.yaml"),      # Must exist
+        FileSpec.optional("config/local.yaml"),     # Skipped if missing
+        FileSpec.required("config/production.yaml") # Must exist
+    ])
+
+    # Convenience method for single optional file
+    config = Config.load("config/base.yaml")
+    config = config.optional("config/local.yaml")  # Merges if exists, no-op if missing
+    ```
+
+=== "Rust"
+
+    ```rust
+    use holoconf::{Config, FileSpec};
+
+    fn main() -> Result<(), holoconf::Error> {
+        let config = Config::load_merged_with_specs(&[
+            FileSpec::required("config/base.yaml"),
+            FileSpec::optional("config/local.yaml"),
+            FileSpec::required("config/production.yaml"),
+        ])?;
+
+        Ok(())
+    }
+    ```
+
+### Behavior
+
+- **Required files** (`FileSpec.required()`): Must exist. Returns an error if the file is not found.
+- **Optional files** (`FileSpec.optional()`): Silently skipped if missing. Merged normally if present.
+- **String paths**: When using `load_merged()` with plain strings, all files are treated as required.
+
+### Common Pattern: Local Overrides
+
+A typical setup with optional local overrides:
+
+```
+config/
+├── base.yaml           # Committed, shared defaults
+├── production.yaml     # Committed, production settings
+└── local.yaml          # .gitignored, developer-specific overrides
+```
+
+=== "Python"
+
+    ```python
+    from holoconf import Config, FileSpec
+    import os
+
+    env = os.environ.get("APP_ENV", "development")
+
+    config = Config.load_merged_with_specs([
+        FileSpec.required("config/base.yaml"),
+        FileSpec.required(f"config/{env}.yaml"),
+        FileSpec.optional("config/local.yaml"),  # Developer overrides
+    ])
+    ```
+
+=== "Rust"
+
+    ```rust
+    use holoconf::{Config, FileSpec};
+    use std::env;
+
+    fn main() -> Result<(), holoconf::Error> {
+        let env = env::var("APP_ENV").unwrap_or_else(|_| "development".into());
+
+        let config = Config::load_merged_with_specs(&[
+            FileSpec::required("config/base.yaml"),
+            FileSpec::required(format!("config/{}.yaml", env)),
+            FileSpec::optional("config/local.yaml"),
+        ])?;
+
+        Ok(())
+    }
+    ```
+
 See [ADR-004 Config Merging](../adr/ADR-004-config-merging.md) for the design rationale.

--- a/packages/python/holoconf/src/holoconf/__init__.py
+++ b/packages/python/holoconf/src/holoconf/__init__.py
@@ -23,12 +23,13 @@ from holoconf._holoconf import (
     CircularReferenceError,
     # Classes
     Config,
+    FileSpec,
     # Exceptions
     HoloconfError,
     ParseError,
     PathNotFoundError,
-    ResolverError,
     ResolvedValue,
+    ResolverError,
     Schema,
     TypeCoercionError,
     ValidationError,
@@ -39,6 +40,7 @@ __all__ = [
     "CircularReferenceError",
     # Classes
     "Config",
+    "FileSpec",
     # Exceptions
     "HoloconfError",
     "ParseError",

--- a/packages/python/holoconf/src/holoconf/_holoconf.pyi
+++ b/packages/python/holoconf/src/holoconf/_holoconf.pyi
@@ -5,6 +5,63 @@ This module provides type hints for the Rust PyO3 bindings.
 
 from typing import Any
 
+class FileSpec:
+    """File specification for optional file support.
+
+    Use this to mark files as optional in load_merged_with_specs().
+    Optional files that don't exist are silently skipped during merging.
+
+    Example:
+        >>> config = Config.load_merged_with_specs([
+        ...     FileSpec.required("base.yaml"),
+        ...     FileSpec.optional("local.yaml"),  # Won't error if missing
+        ... ])
+    """
+
+    def __init__(self, path: str) -> None:
+        """Create a FileSpec for a required file.
+
+        Args:
+            path: Path to the config file
+        """
+        ...
+
+    @staticmethod
+    def optional(path: str) -> FileSpec:
+        """Create a FileSpec for an optional file.
+
+        Optional files that don't exist are silently skipped.
+
+        Args:
+            path: Path to the config file
+
+        Returns:
+            A FileSpec marking the file as optional
+        """
+        ...
+
+    @staticmethod
+    def required(path: str) -> FileSpec:
+        """Create a FileSpec for a required file.
+
+        Args:
+            path: Path to the config file
+
+        Returns:
+            A FileSpec marking the file as required
+        """
+        ...
+
+    @property
+    def is_optional(self) -> bool:
+        """Check if this file is optional."""
+        ...
+
+    @property
+    def path(self) -> str:
+        """Get the path."""
+        ...
+
 class Config:
     """Configuration object for loading and accessing configuration values.
 
@@ -73,6 +130,7 @@ class Config:
         """Load and merge multiple YAML files.
 
         Files are merged in order, with later files overriding earlier ones.
+        All files are required - use load_merged_with_specs() for optional files.
 
         Args:
             paths: List of paths to YAML files
@@ -83,6 +141,53 @@ class Config:
         Raises:
             ParseError: If any file cannot be parsed
             HoloconfError: If any file cannot be read
+        """
+        ...
+
+    @staticmethod
+    def load_merged_with_specs(specs: list[FileSpec]) -> Config:
+        """Load and merge multiple YAML files with optional file support.
+
+        Files are merged in order, with later files overriding earlier ones.
+        Optional files that don't exist are silently skipped.
+
+        Args:
+            specs: List of FileSpec objects (use FileSpec.optional() for optional files)
+
+        Returns:
+            A new Config object with merged configuration
+
+        Raises:
+            ParseError: If any file cannot be parsed
+            HoloconfError: If any required file cannot be read
+
+        Example:
+            >>> config = Config.load_merged_with_specs([
+            ...     FileSpec.required("base.yaml"),
+            ...     FileSpec.required("environment.yaml"),
+            ...     FileSpec.optional("local.yaml"),  # Won't error if missing
+            ... ])
+        """
+        ...
+
+    @staticmethod
+    def optional(path: str) -> FileSpec:
+        """Create a FileSpec for an optional file.
+
+        Convenience method equivalent to FileSpec.optional(path).
+        Use with load_merged_with_specs().
+
+        Args:
+            path: Path to the config file
+
+        Returns:
+            A FileSpec marking the file as optional
+
+        Example:
+            >>> config = Config.load_merged_with_specs([
+            ...     FileSpec("base.yaml"),           # Required
+            ...     Config.optional("local.yaml"),   # Optional
+            ... ])
         """
         ...
 

--- a/tests/acceptance/merging/optional_files.yaml
+++ b/tests/acceptance/merging/optional_files.yaml
@@ -1,0 +1,205 @@
+suite: optional_files
+description: Tests for optional file support in config merging
+
+tests:
+  - name: optional_file_missing_is_skipped
+    given:
+      files:
+        base.yaml: |
+          database:
+            host: localhost
+            port: 5432
+      config_merge_specs:
+        - path: base.yaml
+          optional: false
+        - path: local.yaml
+          optional: true  # Does not exist, should be skipped
+    when:
+      access: database.host
+    then:
+      value: localhost
+
+  - name: optional_file_exists_is_merged
+    given:
+      files:
+        base.yaml: |
+          database:
+            host: localhost
+            port: 5432
+        local.yaml: |
+          database:
+            host: prod-db
+      config_merge_specs:
+        - path: base.yaml
+          optional: false
+        - path: local.yaml
+          optional: true
+    when:
+      access: database.host
+    then:
+      value: prod-db
+
+  - name: required_file_missing_errors
+    given:
+      files:
+        base.yaml: |
+          key: value
+      config_merge_specs:
+        - path: base.yaml
+          optional: false
+        - path: missing.yaml
+          optional: false  # Required, should error
+    when:
+      access: key
+    then:
+      error:
+        message_contains: "File not found"
+
+  - name: all_optional_missing_returns_empty
+    given:
+      files: {}  # No files created
+      config_merge_specs:
+        - path: optional1.yaml
+          optional: true
+        - path: optional2.yaml
+          optional: true
+    when:
+      export: dict
+      resolve: true
+    then:
+      value: {}
+
+  - name: mixed_required_and_optional_files
+    given:
+      files:
+        required1.yaml: |
+          app:
+            name: myapp
+            debug: false
+        required2.yaml: |
+          database:
+            host: localhost
+        optional_exists.yaml: |
+          app:
+            debug: true
+          database:
+            port: 5432
+      config_merge_specs:
+        - path: required1.yaml
+          optional: false
+        - path: optional_missing.yaml
+          optional: true  # Does not exist, should be skipped
+        - path: required2.yaml
+          optional: false
+        - path: optional_exists.yaml
+          optional: true  # Exists, should be merged
+    when:
+      access: app.debug
+    then:
+      value: true
+
+  - name: optional_file_overrides_values
+    given:
+      files:
+        base.yaml: |
+          server:
+            host: "0.0.0.0"
+            port: 8080
+            timeout: 30
+        override.yaml: |
+          server:
+            port: 9000
+      config_merge_specs:
+        - path: base.yaml
+          optional: false
+        - path: override.yaml
+          optional: true
+    when:
+      access: server.port
+    then:
+      value: 9000
+
+  - name: optional_file_preserves_unoverwritten_values
+    given:
+      files:
+        base.yaml: |
+          server:
+            host: "0.0.0.0"
+            port: 8080
+            timeout: 30
+        override.yaml: |
+          server:
+            port: 9000
+      config_merge_specs:
+        - path: base.yaml
+          optional: false
+        - path: override.yaml
+          optional: true
+    when:
+      access: server.timeout
+    then:
+      value: 30
+
+  - name: string_specs_treated_as_required
+    given:
+      files:
+        base.yaml: |
+          key: value
+      config_merge_specs:
+        - base.yaml  # String, should be treated as required
+    when:
+      access: key
+    then:
+      value: value
+
+  - name: optional_file_deep_merge
+    given:
+      files:
+        base.yaml: |
+          database:
+            connection:
+              host: localhost
+              port: 5432
+              pool:
+                min: 5
+                max: 10
+        local.yaml: |
+          database:
+            connection:
+              pool:
+                max: 50
+      config_merge_specs:
+        - path: base.yaml
+          optional: false
+        - path: local.yaml
+          optional: true
+    when:
+      access: database.connection.pool.max
+    then:
+      value: 50
+
+  - name: optional_file_deep_merge_preserves_siblings
+    given:
+      files:
+        base.yaml: |
+          database:
+            connection:
+              host: localhost
+              port: 5432
+              pool:
+                min: 5
+                max: 10
+        local.yaml: |
+          database:
+            connection:
+              pool:
+                max: 50
+      config_merge_specs:
+        - path: base.yaml
+          optional: false
+        - path: local.yaml
+          optional: true
+    when:
+      access: database.connection.pool.min
+    then:
+      value: 5


### PR DESCRIPTION
## Summary

Add `FileSpec` type and `Config.load_merged_with_specs()` for optional file support during config merging. Optional files that don't exist are silently skipped, enabling patterns like local developer overrides.

## Related Issue

Relates to FEAT-003 Config Merging specification

## Spec / ADR

- Spec: `docs/specs/features/FEAT-003-config-merging.md`

## Changes

- [x] Rust core (`crates/holoconf-core/`)
- [x] Python bindings (`crates/holoconf-python/`)
- [ ] CLI (`crates/holoconf-cli/`)
- [x] Documentation (`docs/`)
- [x] Tests

## Checklist

- [x] `make check` passes
- [x] Added/updated tests
- [x] Updated CHANGELOG.md (if user-facing)
- [x] Updated type stubs (if Python API changed)
- [x] Updated docs (if user-facing)