### PR TITLE
feat: framework-level default/sensitive handling and coverage improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### Resolver Syntax (Breaking Change)
+- **Keyword-only syntax for default and sensitive options** - Resolver options now use keyword argument syntax exclusively
+  - Old syntax: `${env:VAR,fallback_value}` (positional default)
+  - New syntax: `${env:VAR,default=fallback_value}` (keyword default)
+  - Sensitive flag: `${env:SECRET,sensitive=true}`
+  - Both combined: `${env:VAR,default=fallback,sensitive=true}`
+- **Framework-level default/sensitive handling** - All resolvers now consistently support `default=` and `sensitive=` options
+  - Lazy evaluation: default values only resolved when primary resolver fails
+  - Works with any resolver: `${file:./config.yaml,default={}}`, `${http:...,default=fallback}`
+  - Sensitive marking propagates correctly through resolution chain
+
 ### Added
 
 #### Optional File Support

--- a/docs/specs/features/FEAT-006-cli.md
+++ b/docs/specs/features/FEAT-006-cli.md
@@ -1,5 +1,13 @@
 # FEAT-006: Command Line Interface
 
+## Status
+
+Draft
+
+## Changelog
+
+- 2026-01-11: Removed standalone `holoconf sources` command; use `holoconf dump --sources` instead
+
 ## Overview
 
 Provide a `holoconf` CLI for validating configs, resolving values, debugging, and generating documentation outside of application code.
@@ -116,6 +124,7 @@ holoconf dump base.yaml production.yaml --resolve
 | `--no-redact` | Don't redact sensitive values (requires `--resolve`) |
 | `--format, -f` | Output format: `yaml` (default), `json` |
 | `--output, -o` | Write to file instead of stdout |
+| `--sources` | Show source file for each value instead of values |
 
 **Output:**
 ```yaml
@@ -128,6 +137,21 @@ database:
 api:
   endpoint: https://api.example.com
   timeout: 30
+
+$ holoconf dump base.yaml production.yaml --sources
+database.host         base.yaml
+database.port         base.yaml
+database.pool.min     base.yaml
+database.pool.max     production.yaml (overrides base.yaml)
+api.endpoint          production.yaml
+api.timeout           production.yaml
+
+$ holoconf dump base.yaml production.yaml --sources --format json
+{
+  "database.host": {"source": "base.yaml"},
+  "database.port": {"source": "base.yaml"},
+  "database.pool.max": {"source": "production.yaml", "overrides": "base.yaml"}
+}
 ```
 
 ### `holoconf get`
@@ -159,33 +183,6 @@ holoconf get config.yaml database --format json
 | `--resolve, -r` | Resolve interpolations |
 | `--format, -f` | Output format: `text` (default), `json`, `yaml` |
 | `--default, -d` | Default value if key not found |
-
-### `holoconf sources`
-
-Show where each config value comes from (for debugging merges).
-
-```bash
-holoconf sources base.yaml production.yaml local.yaml
-```
-
-**Output:**
-```
-$ holoconf sources base.yaml production.yaml local.yaml
-database.host         base.yaml:3
-database.port         base.yaml:4
-database.pool.min     base.yaml:6
-database.pool.max     production.yaml:4    (overrides base.yaml:7)
-api.endpoint          production.yaml:8
-api.timeout           local.yaml:2         (overrides production.yaml:9)
-logging.level         local.yaml:5         (overrides base.yaml:12)
-```
-
-**Options:**
-
-| Option | Description |
-|--------|-------------|
-| `--path, -p` | Filter to specific path prefix |
-| `--format, -f` | Output format: `text` (default), `json` |
 
 ### `holoconf schema`
 
@@ -334,7 +331,7 @@ repos:
 
 ```bash
 # See which file each value comes from
-holoconf sources base.yaml env/production.yaml local.yaml
+holoconf dump base.yaml env/production.yaml local.yaml --sources
 
 # See the final merged result
 holoconf dump base.yaml env/production.yaml local.yaml

--- a/docs/specs/features/FEAT-007-aws-resolvers.md
+++ b/docs/specs/features/FEAT-007-aws-resolvers.md
@@ -1,0 +1,477 @@
+# FEAT-007: AWS Resolvers
+
+## Status
+
+Draft
+
+## Changelog
+
+- 2026-01-11: Initial draft
+
+## Overview
+
+Provide AWS-specific resolvers for fetching configuration values from AWS services: SSM Parameter Store, CloudFormation outputs, and S3 objects. These resolvers are distributed as a separate package (`holoconf-aws`) to keep the core library lean.
+
+## User Stories
+
+- As a developer, I want to read secrets from SSM Parameter Store so I can manage sensitive config securely
+- As a developer, I want to reference CloudFormation stack outputs so my config stays in sync with infrastructure
+- As a developer, I want to include shared config files from S3 so teams can share configuration
+- As a developer, I want to mock AWS calls in tests using moto so I can test locally
+
+## Dependencies
+
+- [ADR-002: Resolver Architecture](../../adr/ADR-002-resolver-architecture.md)
+- [FEAT-001: Configuration File Loading](FEAT-001-config-loading.md)
+- [FEAT-002: Core Resolvers](FEAT-002-core-resolvers.md)
+
+## Package Structure
+
+AWS resolvers are provided as a separate package to avoid bundling AWS SDK dependencies in the core library:
+
+```
+crates/
+  holoconf-aws/           # Rust crate
+    Cargo.toml
+    src/
+      lib.rs              # Re-exports, resolver registration
+      ssm.rs              # SSM Parameter Store resolver
+      cfn.rs              # CloudFormation outputs resolver
+      s3.rs               # S3 resolver
+      client.rs           # AWS SDK client management
+      cache.rs            # TTL-based value caching
+
+packages/
+  python/
+    holoconf-aws/         # Python package (separate wheel)
+      pyproject.toml
+      src/holoconf_aws/
+        __init__.py
+        _holoconf_aws.pyi
+```
+
+## Installation
+
+```bash
+# Python
+pip install holoconf holoconf-aws
+
+# Rust
+cargo add holoconf-core holoconf-aws
+```
+
+## Registration
+
+AWS resolvers must be explicitly registered before use:
+
+```python
+import holoconf
+import holoconf_aws
+
+# Register all AWS resolvers
+holoconf_aws.register()
+
+# Now AWS resolvers are available
+config = holoconf.Config.from_yaml("config.yaml")
+```
+
+```rust
+use holoconf_core::Config;
+use holoconf_aws;
+
+// Register AWS resolvers
+holoconf_aws::register();
+
+let config = Config::from_yaml_file("config.yaml")?;
+```
+
+## Resolvers
+
+### 1. SSM Parameter Store (`ssm`)
+
+Fetches values from AWS Systems Manager Parameter Store.
+
+**Arguments:**
+
+| Position | Name | Required | Description |
+|----------|------|----------|-------------|
+| 1 | path | Yes | SSM parameter path (must start with `/`) |
+
+**Keyword Arguments:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `default` | any | none | Default value if parameter not found |
+| `sensitive` | bool | auto | Override sensitivity detection |
+| `region` | string | SDK default | AWS region for this lookup |
+| `profile` | string | SDK default | AWS profile for credentials |
+
+**Examples:**
+```yaml
+# Basic usage
+database:
+  host: ${ssm:/myapp/prod/db-host}
+  password: ${ssm:/myapp/prod/db-password}
+
+# With default value
+timeout: ${ssm:/myapp/prod/timeout,default=30}
+
+# Explicit sensitivity
+api_key: ${ssm:/myapp/prod/api-key,sensitive=true}
+
+# Cross-region lookup
+other_region: ${ssm:/myapp/config,region=us-west-2}
+
+# Cross-account (via profile)
+other_account: ${ssm:/shared/config,profile=shared-account}
+
+# Access Secrets Manager via SSM
+secret: ${ssm:/aws/reference/secretsmanager/myapp/db-creds}
+```
+
+**Behavior:**
+- Fetches parameter with automatic decryption (`WithDecryption=true`)
+- Parameter type is detected automatically and handled appropriately (see table below)
+- Parameters not found raise `ResolverError` (unless default provided)
+- Supports Secrets Manager access via `/aws/reference/secretsmanager/` prefix
+
+**Parameter Type Handling:**
+
+| SSM Type | Return Type | Default Sensitive | Notes |
+|----------|-------------|-------------------|-------|
+| String | string | No | Plain text parameter |
+| SecureString | string | Yes | Encrypted parameter, auto-decrypted |
+| StringList | array of strings | No | Comma-separated list, automatically split |
+
+All types support the `sensitive` keyword argument to override the default:
+
+```yaml
+# String - mark as sensitive
+internal_config: ${ssm:/app/internal-config,sensitive=true}
+
+# SecureString - sensitive by default, can override (rare)
+non_secret_encrypted: ${ssm:/app/some-param,sensitive=false}
+
+# StringList - mark as sensitive
+internal_ips: ${ssm:/app/internal-ips,sensitive=true}
+```
+
+**StringList Example:**
+
+```yaml
+# SSM parameter /app/allowed-origins contains: "https://example.com,https://app.example.com,https://admin.example.com"
+# Type: StringList
+
+# Automatically returns as array
+allowed_origins: ${ssm:/app/allowed-origins}
+# Result: ["https://example.com", "https://app.example.com", "https://admin.example.com"]
+
+# Access individual elements
+primary_origin: ${ssm:/app/allowed-origins}[0]
+# Result: "https://example.com"
+```
+
+**Secrets Manager Access:**
+
+SSM provides transparent access to Secrets Manager secrets via a special path prefix. This is the recommended way to access secrets:
+
+```yaml
+# Instead of a separate secretsmanager resolver:
+db_password: ${ssm:/aws/reference/secretsmanager/myapp/db-password}
+
+# The path after the prefix is the Secrets Manager secret name
+api_key: ${ssm:/aws/reference/secretsmanager/prod/api-keys/stripe}
+```
+
+### 2. CloudFormation Outputs (`cfn`)
+
+Fetches outputs from CloudFormation stacks.
+
+**Arguments:**
+
+| Position | Name | Required | Description |
+|----------|------|----------|-------------|
+| 1 | stack/output | Yes | Stack name and output key separated by `/` |
+
+**Keyword Arguments:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `default` | any | none | Default value if output not found |
+| `region` | string | SDK default | AWS region for this lookup |
+| `profile` | string | SDK default | AWS profile for credentials |
+| `sensitive` | bool | `false` | Mark value as sensitive |
+
+**Examples:**
+```yaml
+database:
+  # Basic usage: stack-name/OutputKey
+  endpoint: ${cfn:my-database-stack/DatabaseEndpoint}
+  port: ${cfn:my-database-stack/DatabasePort}
+
+# With default value
+bucket: ${cfn:my-stack/BucketName,default=my-default-bucket}
+
+# Cross-region lookup
+west_bucket: ${cfn:my-stack/BucketName,region=us-west-2}
+
+# Cross-account (via profile)
+shared_vpc: ${cfn:shared-infra/VpcId,profile=network-account}
+```
+
+**Behavior:**
+- Fetches stack outputs via `DescribeStacks` API
+- If output not found and no default provided, raises `ResolverError`
+- If output not found and default is provided, returns default
+- Stack not found or not in `*_COMPLETE` state raises `ResolverError`
+- Not sensitive by default (stack outputs are typically public)
+
+### 3. S3 (`s3`)
+
+Fetches objects from Amazon S3.
+
+**Arguments:**
+
+| Position | Name | Required | Description |
+|----------|------|----------|-------------|
+| 1 | bucket/key | Yes | S3 bucket and object key separated by `/` (first `/` separates bucket from key) |
+
+**Keyword Arguments:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `default` | any | none | Default value if object not found |
+| `parse` | string | `auto` | How to interpret content: `auto`, `yaml`, `json`, `text`, `binary` |
+| `encoding` | string | `utf-8` | Text encoding: `utf-8`, `ascii`, `latin-1` (ignored for `binary`) |
+| `region` | string | SDK default | AWS region for this lookup |
+| `profile` | string | SDK default | AWS profile for credentials |
+| `sensitive` | bool | `false` | Mark value as sensitive |
+
+**Parse Modes:**
+
+| Mode | Return Type | Description |
+|------|-------------|-------------|
+| `auto` | varies | Detect by object key extension or `Content-Type` header |
+| `yaml` | structured data | Parse as YAML, accessible via dot notation |
+| `json` | structured data | Parse as JSON, accessible via dot notation |
+| `text` | string | Return raw text content |
+| `binary` | bytes | Return raw bytes (`bytes` in Python, `Vec<u8>` in Rust) |
+
+**Behavior:**
+- Fetches object content via `GetObject` API
+- If object not found and no default provided, raises `ResolverError`
+- If object not found and default is provided, returns default
+- When `parse=auto`, format is detected by key extension (`.yaml`, `.yml`, `.json` → parsed; else → text)
+- Parsed content (YAML/JSON) returns a Config object for nested access
+- Text content returns a string
+- Binary content returns raw bytes (useful for certificates, keys, images)
+- Not sensitive by default; use `sensitive=true` for secrets
+
+**Examples:**
+```yaml
+# Auto-detect format by key extension
+shared_config: ${s3:my-bucket/configs/shared.yaml}
+
+# With default if object doesn't exist
+optional_config: ${s3:my-bucket/configs/optional.yaml,default={}}
+
+# Explicit parsing mode
+feature_flags: ${s3:config-bucket/flags.json,parse=json}
+
+# Raw text content
+readme: ${s3:my-bucket/docs/README.md,parse=text}
+
+# Binary file (certificates, keys, images)
+certificate: ${s3:my-bucket/certs/ca.pem,parse=binary}
+client_cert: ${s3:my-bucket/certs/client.p12,parse=binary,sensitive=true}
+
+# Cross-region lookup
+remote_config: ${s3:other-bucket/config.yaml,region=eu-west-1}
+
+# Cross-account (via profile)
+shared_config: ${s3:shared-bucket/common.yaml,profile=shared-account}
+
+# Different encoding for legacy files
+legacy_data: ${s3:my-bucket/legacy/data.txt,encoding=latin-1}
+
+# Mark as sensitive
+secret_config: ${s3:my-bucket/secrets/config.yaml,sensitive=true}
+```
+
+## Credential Resolution
+
+All AWS resolvers use the standard AWS SDK credential provider chain:
+
+1. **Environment variables** (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+2. **Shared credentials file** (`~/.aws/credentials`)
+3. **Shared config file** (`~/.aws/config`) with profile support
+4. **Web Identity Token** (for EKS workloads)
+5. **ECS Container credentials** (for ECS tasks)
+6. **EC2 Instance Metadata** (IMDS v2 for EC2 instances)
+
+The `region` keyword argument overrides the region for that specific lookup. The `profile` keyword argument selects a named profile from the shared config files.
+
+## Client Caching
+
+AWS SDK clients are immutable after creation. To avoid creating redundant clients, holoconf-aws caches clients by `(region, profile)` tuple:
+
+```
+Resolution: ${ssm:/path,region=us-west-2,profile=prod}
+    ↓
+Cache lookup: (Some("us-west-2"), Some("prod"))
+    ↓
+Cache miss → Create client → Cache it
+    ↓
+Subsequent calls with same region/profile reuse cached client
+```
+
+The default client (no region/profile overrides) uses key `(None, None)` and resolves credentials via the SDK's default chain.
+
+## Configuration API
+
+For testing and advanced use cases, the global AWS configuration can be overridden:
+
+```python
+import holoconf_aws
+
+# Configure endpoint URL (for moto/LocalStack)
+holoconf_aws.configure(
+    endpoint_url="http://localhost:5000",  # All services
+)
+
+# Or per-service endpoints
+holoconf_aws.configure(
+    ssm_endpoint="http://localhost:5000",
+    s3_endpoint="http://localhost:5000",
+    cfn_endpoint="http://localhost:5000",
+)
+
+# Override default region/profile
+holoconf_aws.configure(
+    region="us-east-1",
+    profile="testing",
+)
+
+# Reset to defaults (clears client cache)
+holoconf_aws.reset()
+```
+
+## Testing with Moto
+
+Since holoconf-aws uses the Rust AWS SDK internally, Python's moto decorators (`@mock_ssm`) won't work. Instead, use moto's server mode:
+
+```python
+# conftest.py
+import pytest
+from moto.server import ThreadedMotoServer
+import boto3
+import holoconf
+import holoconf_aws
+
+@pytest.fixture(scope="session")
+def moto_server():
+    """Start moto server for the test session."""
+    server = ThreadedMotoServer(port=5555)
+    server.start()
+    yield "http://localhost:5555"
+    server.stop()
+
+@pytest.fixture
+def aws_config(moto_server):
+    """Configure holoconf-aws to use moto and set up test data."""
+    # Point holoconf-aws at moto
+    holoconf_aws.configure(endpoint_url=moto_server)
+
+    # Set up test data using boto3 (also pointed at moto)
+    ssm = boto3.client("ssm", endpoint_url=moto_server, region_name="us-east-1")
+    ssm.put_parameter(Name="/app/db-host", Value="test-db.local", Type="String")
+    ssm.put_parameter(Name="/app/db-password", Value="secret123", Type="SecureString")
+
+    yield
+
+    # Reset holoconf-aws (clears client cache)
+    holoconf_aws.reset()
+
+def test_ssm_resolver(aws_config):
+    """Test that SSM resolver fetches values from moto."""
+    holoconf_aws.register()
+
+    config = holoconf.Config.from_yaml_str("""
+    database:
+      host: ${ssm:/app/db-host}
+      password: ${ssm:/app/db-password}
+    """)
+
+    assert config.get("database.host") == "test-db.local"
+    assert config.get("database.password") == "secret123"
+```
+
+## Error Handling
+
+AWS resolver errors include context about the failed operation:
+
+```python
+try:
+    value = config.get("database.password")
+except ResolverError as e:
+    # e.resolver = "ssm"
+    # e.key = "/app/db-password"
+    # e.message = "Parameter not found"
+    # e.cause = <underlying AWS SDK error>
+```
+
+Common error scenarios:
+
+| Scenario | Error |
+|----------|-------|
+| Parameter/output/object not found | `ResolverError` with "not found" message |
+| Invalid credentials | `ResolverError` with "access denied" message |
+| Network error | `ResolverError` with "connection" message |
+| Stack not ready | `ResolverError` with "stack not in COMPLETE state" |
+
+## Implementation Notes
+
+### Rust Crate
+
+```rust
+// holoconf-aws/src/lib.rs
+use holoconf_core::resolver::Registry;
+
+pub mod ssm;
+pub mod cfn;
+pub mod s3;
+mod client;
+mod cache;
+
+/// Register all AWS resolvers with the global registry
+pub fn register() {
+    let registry = Registry::global();
+    registry.register("ssm", ssm::SsmResolver::new());
+    registry.register("cfn", cfn::CfnResolver::new());
+    registry.register("s3", s3::S3Resolver::new());
+}
+```
+
+### Dependencies
+
+```toml
+# holoconf-aws/Cargo.toml
+[dependencies]
+holoconf-core = { path = "../holoconf-core" }
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-ssm = "1"
+aws-sdk-cloudformation = "1"
+aws-sdk-s3 = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
+```
+
+### Python Bindings
+
+The Python package wraps the Rust crate via PyO3:
+
+```python
+# holoconf_aws/__init__.py
+from ._holoconf_aws import register, configure, reset
+
+__all__ = ["register", "configure", "reset"]
+```

--- a/tests/acceptance/output/redaction.yaml
+++ b/tests/acceptance/output/redaction.yaml
@@ -131,7 +131,7 @@ tests:
     description: Default values can also be marked sensitive
     given:
       config: |
-        token: ${env:HOLOCONF_NONEXISTENT_TOKEN,fallback_token,sensitive=true}
+        token: ${env:HOLOCONF_NONEXISTENT_TOKEN,default=fallback_token,sensitive=true}
     when:
       dump:
         format: yaml

--- a/tests/acceptance/resolvers/env_resolver.yaml
+++ b/tests/acceptance/resolvers/env_resolver.yaml
@@ -16,7 +16,7 @@ tests:
   - name: uses_default_when_missing
     given:
       config: |
-        port: ${env:HOLOCONF_UNDEFINED_VAR,3000}
+        port: ${env:HOLOCONF_UNDEFINED_VAR,default=3000}
     when:
       access: port
     then:
@@ -38,7 +38,7 @@ tests:
       env:
         HOLOCONF_FALLBACK: "fallback_value"
       config: |
-        value: ${env:HOLOCONF_UNDEFINED,${env:HOLOCONF_FALLBACK}}
+        value: ${env:HOLOCONF_UNDEFINED,default=${env:HOLOCONF_FALLBACK}}
     when:
       access: value
     then:
@@ -54,3 +54,42 @@ tests:
       access: bucket
     then:
       value: "myapp-prod-data"
+
+  - name: sensitive_flag_marks_value_for_redaction
+    given:
+      env:
+        HOLOCONF_SECRET: "super_secret_value"
+      config: |
+        api_key: ${env:HOLOCONF_SECRET,sensitive=true}
+    when:
+      dump:
+        format: yaml
+        redact: true
+    then:
+      output_contains: "[REDACTED]"
+      output_not_contains: "super_secret_value"
+
+  - name: sensitive_with_default
+    given:
+      config: |
+        password: ${env:HOLOCONF_UNDEFINED_SECRET,default=default_secret,sensitive=true}
+    when:
+      dump:
+        format: yaml
+        redact: true
+    then:
+      output_contains: "[REDACTED]"
+      output_not_contains: "default_secret"
+
+  - name: lazy_default_not_called_when_value_exists
+    description: Default resolver should NOT be invoked when main value exists
+    given:
+      env:
+        HOLOCONF_MAIN_VAR: "main_value"
+        HOLOCONF_DEFAULT_VAR: "should_not_be_used"
+      config: |
+        value: ${env:HOLOCONF_MAIN_VAR,default=${env:HOLOCONF_DEFAULT_VAR}}
+    when:
+      access: value
+    then:
+      value: "main_value"

--- a/tests/acceptance/resolvers/self_resolver.yaml
+++ b/tests/acceptance/resolvers/self_resolver.yaml
@@ -61,3 +61,44 @@ tests:
       access: final.region
     then:
       value: "us-east-1"
+
+  - name: relative_reference_parent
+    description: Going up levels with double dots
+    given:
+      config: |
+        database:
+          host: localhost
+          connection:
+            url: "postgres://${..host}:5432"
+    when:
+      access: database.connection.url
+    then:
+      value: "postgres://localhost:5432"
+
+  - name: self_reference_preserves_type
+    description: Self-references should preserve the type of the referenced value
+    given:
+      config: |
+        defaults:
+          count: 42
+          enabled: true
+        app:
+          count: ${defaults.count}
+          enabled: ${defaults.enabled}
+    when:
+      access: app.count
+    then:
+      value: 42
+
+  - name: self_reference_in_string
+    description: Self-references in string concatenation
+    given:
+      config: |
+        parts:
+          host: localhost
+          port: 5432
+        connection: "postgres://${parts.host}:${parts.port}/db"
+    when:
+      access: connection
+    then:
+      value: "postgres://localhost:5432/db"


### PR DESCRIPTION
## Summary

Implements ADR-011 framework-level handling for resolver kwargs and brings code coverage above 90% target (ADR-013).

Key user-facing changes:
- **Breaking**: Resolver options now use keyword-only syntax (`default=value` instead of positional)
- All resolvers now consistently support `default=` and `sensitive=` options with lazy evaluation

## Related Issue

N/A

## Spec / ADR

- [ADR-011: Interpolation Syntax](docs/adr/ADR-011-interpolation-syntax.md) - Framework-level default/sensitive handling
- [ADR-013: Code Coverage](docs/adr/ADR-013-code-coverage.md) - Coverage targets
- [FEAT-002: Core Resolvers](docs/specs/features/FEAT-002-core-resolvers.md) - Updated resolver behavior

## Changes

- [x] Rust core (`crates/holoconf-core/`)
- [ ] Python bindings (`crates/holoconf-python/`)
- [ ] CLI (`crates/holoconf-cli/`)
- [x] Documentation (`docs/`)
- [x] Tests

## Checklist

- [x] `make check` passes
- [x] Added/updated tests
- [x] Updated CHANGELOG.md (if user-facing)
- [ ] Updated type stubs (if Python API changed)
- [x] Updated docs (if user-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)