### PR TITLE
docs: update examples to use keyword syntax for default/sensitive

### DIFF
--- a/docs/adr/ADR-013-testing-architecture.md
+++ b/docs/adr/ADR-013-testing-architecture.md
@@ -115,7 +115,7 @@ tests:
   - name: uses_default_when_missing
     given:
       config: |
-        port: ${env:UNDEFINED_VAR,3000}
+        port: ${env:UNDEFINED_VAR,default=3000}
     when:
       access: port
     then:

--- a/docs/api/cli/index.md
+++ b/docs/api/cli/index.md
@@ -167,7 +167,7 @@ $ holoconf dump config.yaml
 app:
   name: my-application
 database:
-  host: ${env:DB_HOST,localhost}
+  host: ${env:DB_HOST,default=localhost}
 
 # Dump resolved as JSON
 $ holoconf dump config.yaml --resolve --format json

--- a/docs/api/python/index.md
+++ b/docs/api/python/index.md
@@ -70,8 +70,8 @@ config.validate(schema)
 ```python
 # config.yaml:
 # database:
-#   host: ${env:DB_HOST,localhost}
-#   port: ${env:DB_PORT,5432}
+#   host: ${env:DB_HOST,default=localhost}
+#   port: ${env:DB_PORT,default=5432}
 
 config = Config.load("config.yaml")
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -84,7 +84,7 @@ from holoconf import Config
 
 config = Config.from_string("""
 database:
-  host: ${env:DB_HOST,localhost}
+  host: ${env:DB_HOST,default=localhost}
 """)
 
 # Inspect values

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -46,12 +46,12 @@ app:
   debug: false
 
 database:
-  host: ${env:DB_HOST,localhost}
-  port: ${env:DB_PORT,5432}
-  name: ${env:DB_NAME,myapp}
+  host: ${env:DB_HOST,default=localhost}
+  port: ${env:DB_PORT,default=5432}
+  name: ${env:DB_NAME,default=myapp}
 
 logging:
-  level: ${env:LOG_LEVEL,info}
+  level: ${env:LOG_LEVEL,default=info}
   format: json
 ```
 
@@ -59,7 +59,7 @@ This configuration demonstrates several HoloConf features:
 
 - **Nested structure** - Values organized hierarchically
 - **Environment variables** - `${env:VAR_NAME}` resolves to environment variable values
-- **Default values** - `${env:VAR_NAME,default}` provides fallbacks when variables aren't set
+- **Default values** - `${env:VAR_NAME,default=value}` provides fallbacks when variables aren't set
 
 ## Loading Configuration
 
@@ -117,7 +117,7 @@ This configuration demonstrates several HoloConf features:
       debug: false
     database:
       host: localhost
-      port: 5432
+      port: "5432"
       name: myapp
     logging:
       level: info
@@ -141,7 +141,7 @@ HoloConf supports deep nesting and provides convenient access patterns:
     # Get a subsection as a dict
     db_config = config.get("database")
     print(db_config)
-    # {'host': 'localhost', 'port': 5432, 'name': 'myapp'}
+    # {'host': 'localhost', 'port': '5432', 'name': 'myapp'}
 
     # Check if a path exists
     if config.get("app.debug"):

--- a/docs/guide/interpolation.md
+++ b/docs/guide/interpolation.md
@@ -1,15 +1,13 @@
 # Interpolation
 
-!!! note "Coming Soon"
-    This page is under construction. See [ADR-011 Interpolation Syntax](../adr/ADR-011-interpolation-syntax.md) for technical details.
-
 ## Overview
 
 HoloConf supports interpolation syntax to dynamically resolve values at access time. The general syntax is:
 
 ```
 ${resolver:argument}
-${resolver:argument,default}
+${resolver:argument,default=value}
+${resolver:argument,sensitive=true}
 ```
 
 ## Quick Reference
@@ -17,12 +15,29 @@ ${resolver:argument,default}
 | Syntax | Description | Example |
 |--------|-------------|---------|
 | `${env:VAR}` | Environment variable | `${env:DATABASE_URL}` |
-| `${env:VAR,default}` | Environment variable with default | `${env:PORT,8080}` |
+| `${env:VAR,default=value}` | Environment variable with default | `${env:PORT,default=8080}` |
+| `${env:VAR,sensitive=true}` | Mark as sensitive (redacted in output) | `${env:API_KEY,sensitive=true}` |
 | `${path.to.value}` | Self-reference (absolute) | `${database.host}` |
 | `${.sibling}` | Self-reference (relative) | `${.port}` |
 | `${..parent.value}` | Self-reference (parent) | `${..shared.timeout}` |
 | `${file:path}` | Include file content | `${file:./secrets.yaml}` |
 | `${http:url}` | Fetch from HTTP endpoint | `${http:https://config.example.com/settings}` |
+
+## Keyword Arguments
+
+All resolvers support two framework-level keyword arguments:
+
+- **`default=value`** - Fallback value if the resolver fails (e.g., env var not set, file not found)
+- **`sensitive=true`** - Mark value as sensitive for redaction in output
+
+These can be combined:
+
+```yaml
+api_key: ${env:API_KEY,default=dev-key,sensitive=true}
+```
+
+!!! note "Lazy Default Resolution"
+    Default values are resolved lazily - if the primary resolver succeeds, the default is never evaluated. This allows defaults to contain other resolvers without causing errors.
 
 ## Examples
 
@@ -33,7 +48,7 @@ ${resolver:argument,default}
     ```python
     # config.yaml:
     # database:
-    #   url: ${env:DATABASE_URL,postgres://localhost/mydb}
+    #   url: ${env:DATABASE_URL,default=postgres://localhost/mydb}
 
     from holoconf import Config
     import os
@@ -77,6 +92,35 @@ cache:
   timeout: ${defaults.timeout}
 ```
 
+### Sensitive Values
+
+Mark values as sensitive to automatically redact them in dumps:
+
+```yaml
+database:
+  host: ${env:DB_HOST,default=localhost}
+  password: ${env:DB_PASSWORD,sensitive=true}
+```
+
+When dumping with redaction:
+
+```python
+config = Config.from_file("config.yaml")
+print(config.to_yaml(redact=True))
+# database:
+#   host: localhost
+#   password: '[REDACTED]'
+```
+
+### Nested Defaults
+
+Default values can contain other resolvers:
+
+```yaml
+# Falls back to FALLBACK_VAR if PRIMARY_VAR is not set
+value: ${env:PRIMARY_VAR,default=${env:FALLBACK_VAR,default=final-fallback}}
+```
+
 ## Escaping
 
 To include a literal `${` in your configuration, escape it with a backslash:
@@ -84,3 +128,8 @@ To include a literal `${` in your configuration, escape it with a backslash:
 ```yaml
 template: "Hello \${name}"  # Literal ${name}, not interpolated
 ```
+
+## See Also
+
+- [ADR-011 Interpolation Syntax](../adr/ADR-011-interpolation-syntax.md) - Technical details and design rationale
+- [Resolvers](resolvers.md) - Detailed resolver documentation

--- a/docs/guide/resolvers.md
+++ b/docs/guide/resolvers.md
@@ -1,11 +1,13 @@
 # Resolvers
 
-!!! note "Coming Soon"
-    This page is under construction. See [FEAT-002 Core Resolvers](../specs/features/FEAT-002-core-resolvers.md) for the full specification.
-
 ## Overview
 
 Resolvers are the mechanism HoloConf uses to dynamically compute configuration values. Each resolver handles a specific type of value source.
+
+All resolvers support two framework-level keyword arguments:
+
+- **`default=value`** - Fallback value if resolution fails
+- **`sensitive=true`** - Mark value as sensitive for redaction
 
 ## Built-in Resolvers
 
@@ -16,8 +18,8 @@ Reads values from environment variables.
 ```yaml
 database:
   host: ${env:DB_HOST}
-  port: ${env:DB_PORT,5432}
-  password: ${env:DB_PASSWORD}
+  port: ${env:DB_PORT,default=5432}
+  password: ${env:DB_PASSWORD,sensitive=true}
 ```
 
 === "Python"
@@ -30,7 +32,7 @@ database:
     config = Config.from_file("config.yaml")
 
     host = config.get("database.host")  # "production-db.example.com"
-    port = config.get("database.port")  # 5432 (default, since DB_PORT not set)
+    port = config.get("database.port")  # "5432" (default, since DB_PORT not set)
     ```
 
 === "Rust"
@@ -44,7 +46,7 @@ database:
         let config = Config::from_file("config.yaml")?;
 
         let host: String = config.get("database.host")?;
-        let port: i64 = config.get("database.port")?;
+        let port: String = config.get("database.port")?;
 
         Ok(())
     }
@@ -62,6 +64,21 @@ endpoints:
   orders: ${base_url}/orders
 ```
 
+#### Relative References
+
+Use `.` for sibling references and `..` to go up levels:
+
+```yaml
+database:
+  host: localhost
+  port: 5432
+  connection:
+    # Reference sibling 'host' (same level)
+    url: postgres://${.host}:${.port}/mydb
+    # Reference parent's sibling
+    timeout: ${..defaults.timeout}
+```
+
 ### File Include (`file`)
 
 Include content from other files.
@@ -71,17 +88,33 @@ Include content from other files.
 app:
   name: my-app
   secrets: ${file:./secrets.yaml}
+  # With default if file doesn't exist
+  optional_config: ${file:./local.yaml,default={}}
 ```
+
+#### File Resolver Options
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `parse=yaml` | Parse as YAML | `${file:data.txt,parse=yaml}` |
+| `parse=json` | Parse as JSON | `${file:data.txt,parse=json}` |
+| `parse=text` | Read as plain text | `${file:data.json,parse=text}` |
+| `parse=auto` | Auto-detect from extension (default) | `${file:config.yaml}` |
+| `encoding=utf-8` | UTF-8 encoding (default) | `${file:data.txt}` |
+| `encoding=base64` | Base64 encode contents | `${file:cert.pem,encoding=base64}` |
+| `encoding=binary` | Return raw bytes | `${file:image.png,encoding=binary}` |
 
 ### HTTP (`http`)
 
 !!! warning "Security"
-    HTTP resolver is disabled by default for security. Enable it explicitly in your configuration.
+    HTTP resolver is disabled by default for security. Enable it explicitly in your configuration options.
 
 Fetch configuration from HTTP endpoints.
 
 ```yaml
 feature_flags: ${http:https://config.example.com/flags.json}
+# With fallback if request fails
+remote_config: ${http:https://api.example.com/config,default={}}
 ```
 
 ## Lazy Resolution
@@ -91,5 +124,31 @@ Resolvers are invoked **lazily** - values are only resolved when accessed, not w
 - Environment variables are read at access time
 - Files are read at access time
 - HTTP requests are made at access time
+- Default values are only resolved if the primary resolver fails
 
 See [ADR-005 Resolver Timing](../adr/ADR-005-resolver-timing.md) for the design rationale.
+
+## Sensitive Values
+
+Mark values as sensitive to prevent them from appearing in logs or dumps:
+
+```yaml
+api:
+  key: ${env:API_KEY,sensitive=true}
+  secret: ${env:API_SECRET,default=dev-secret,sensitive=true}
+```
+
+When dumping configuration with `redact=True`:
+
+```python
+config = Config.from_file("config.yaml")
+print(config.to_yaml(redact=True))
+# api:
+#   key: '[REDACTED]'
+#   secret: '[REDACTED]'
+```
+
+## See Also
+
+- [FEAT-002 Core Resolvers](../specs/features/FEAT-002-core-resolvers.md) - Full specification
+- [Interpolation](interpolation.md) - Interpolation syntax details

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,8 +48,8 @@ HoloConf provides a consistent, powerful configuration management experience acr
 
     # Environment variables are resolved automatically
     # database:
-    #   host: ${env:DB_HOST,localhost}
-    #   port: ${env:DB_PORT,5432}
+    #   host: ${env:DB_HOST,default=localhost}
+    #   port: ${env:DB_PORT,default=5432}
     ```
 
 === "Rust"

--- a/docs/specs/features/FEAT-004-schema-validation.md
+++ b/docs/specs/features/FEAT-004-schema-validation.md
@@ -350,10 +350,10 @@ app:
 
 database:
   host: ${env:DB_HOST}
-  port: ${env:DB_PORT,5432}
+  port: ${env:DB_PORT,default=5432}
 
 logging:
-  level: ${env:LOG_LEVEL,info}
+  level: ${env:LOG_LEVEL,default=info}
 ```
 
 ```python


### PR DESCRIPTION
## Summary

Updates all documentation examples to use the new keyword syntax (`default=value`, `sensitive=true`) introduced in PR #10. This ensures the docs accurately reflect the current API behavior.

## Related Issue

Relates to #10 (framework-level default/sensitive handling)

## Spec / ADR

- [ADR-011 Interpolation Syntax](docs/adr/ADR-011-interpolation-syntax.md) - Documents the keyword syntax decision

## Changes

- [ ] Rust core (`crates/holoconf-core/`)
- [ ] Python bindings (`crates/holoconf-python/`)
- [ ] CLI (`crates/holoconf-cli/`)
- [x] Documentation (`docs/`)
- [ ] Tests

## Checklist

- [x] `make check` passes
- [ ] Added/updated tests
- [ ] Updated CHANGELOG.md (if user-facing)
- [ ] Updated type stubs (if Python API changed)
- [x] Updated docs (if user-facing)

## Files Updated

- `docs/guide/interpolation.md` - Major rewrite with new syntax section, keyword arguments documentation
- `docs/guide/resolvers.md` - Added framework-level keyword arguments intro, sensitive values section
- `docs/guide/getting-started.md` - Updated config examples
- `docs/index.md` - Updated quick example comments
- `docs/api/python/index.md` - Updated environment variable examples
- `docs/api/cli/index.md` - Updated dump command example
- `docs/contributing/testing.md` - Updated debug example
- `docs/specs/features/FEAT-004-schema-validation.md` - Updated config examples
- `docs/adr/ADR-013-testing-architecture.md` - Updated test example