### PR TITLE
feat: apply schema default values to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Schema Default Values
+- **Schema defaults for missing paths** - When a schema is attached to a config, accessing a missing path returns the schema default instead of `PathNotFoundError`
+  - `Config.load("config.yaml", schema="schema.yaml")` - Load with schema attached
+  - `config.set_schema(schema)` - Attach schema to existing config
+  - `config.get_schema()` - Retrieve attached schema
+- **Null-aware default lookup** - If a config value is `null` and the schema doesn't allow `null`, the schema default is used
+- **validate() uses attached schema** - Call `config.validate()` with no args to use the attached schema
+- **CLI --schema flag** - `holoconf get` and `holoconf dump` now accept `--schema` for default values
+- **Enhanced validate output** - `holoconf validate` now shows all validation errors with paths
+
 #### Resolver Extension Packages
 - **Global resolver registry** - Register resolvers once, use everywhere
   - `holoconf.register_resolver(name, func, force=False)` - Python API

--- a/docs/api/cli/index.md
+++ b/docs/api/cli/index.md
@@ -115,6 +115,7 @@ holoconf get <FILES>... <PATH> [OPTIONS]
 | `-r, --resolve` | Resolve interpolations (default: raw value) |
 | `-f, --format` | Output format: `text`, `json`, `yaml` (default: text) |
 | `-d, --default` | Default value if path not found |
+| `--schema` | Path to schema file for default values |
 
 **Examples:**
 
@@ -138,6 +139,10 @@ fallback
 # Merge multiple files, then get
 $ holoconf get base.yaml production.yaml database.host
 prod-db.example.com
+
+# Get with schema defaults (returns schema default if path missing)
+$ holoconf get config.yaml database.pool_size --schema schema.yaml
+10
 ```
 
 ---
@@ -158,6 +163,7 @@ holoconf dump <FILES>... [OPTIONS]
 | `-f, --format` | Output format: `yaml`, `json` (default: yaml) |
 | `-o, --output` | Write to file instead of stdout |
 | `--no-redact` | Don't redact sensitive values |
+| `--schema` | Path to schema file for default values |
 
 **Examples:**
 
@@ -182,6 +188,9 @@ $ holoconf dump base.yaml production.yaml --resolve
 # Write to file
 $ holoconf dump config.yaml --resolve -o resolved.yaml
 ✓ Wrote to resolved.yaml
+
+# Dump with schema defaults applied
+$ holoconf dump config.yaml --schema schema.yaml --resolve
 ```
 
 ---

--- a/tests/acceptance/schema/defaults.yaml
+++ b/tests/acceptance/schema/defaults.yaml
@@ -1,0 +1,223 @@
+suite: schema_defaults
+description: Schema default value behavior
+
+tests:
+  - name: returns_schema_default_for_missing_path
+    given:
+      config: |
+        name: myapp
+      schema: |
+        type: object
+        properties:
+          name:
+            type: string
+          port:
+            type: integer
+            default: 8080
+    when:
+      access: port
+    then:
+      value: 8080
+
+  - name: config_value_overrides_schema_default
+    given:
+      config: |
+        port: 3000
+      schema: |
+        type: object
+        properties:
+          port:
+            type: integer
+            default: 8080
+    when:
+      access: port
+    then:
+      value: 3000
+
+  - name: nested_path_returns_schema_default
+    given:
+      config: |
+        database:
+          host: localhost
+      schema: |
+        type: object
+        properties:
+          database:
+            type: object
+            properties:
+              host:
+                type: string
+              port:
+                type: integer
+                default: 5432
+    when:
+      access: database.port
+    then:
+      value: 5432
+
+  - name: deeply_nested_path_returns_schema_default
+    given:
+      config: |
+        database:
+          connection:
+            host: localhost
+      schema: |
+        type: object
+        properties:
+          database:
+            type: object
+            properties:
+              connection:
+                type: object
+                properties:
+                  host:
+                    type: string
+                  timeout:
+                    type: integer
+                    default: 30
+    when:
+      access: database.connection.timeout
+    then:
+      value: 30
+
+  - name: error_when_missing_path_has_no_default
+    given:
+      config: |
+        name: myapp
+      schema: |
+        type: object
+        properties:
+          name:
+            type: string
+          required_field:
+            type: string
+    when:
+      access: required_field
+    then:
+      error:
+        type: PathNotFoundError
+
+  - name: string_default_value
+    given:
+      config: |
+        port: 8080
+      schema: |
+        type: object
+        properties:
+          port:
+            type: integer
+          host:
+            type: string
+            default: localhost
+    when:
+      access: host
+    then:
+      value: localhost
+
+  - name: boolean_default_value
+    given:
+      config: |
+        name: myapp
+      schema: |
+        type: object
+        properties:
+          name:
+            type: string
+          enabled:
+            type: boolean
+            default: true
+    when:
+      access: enabled
+    then:
+      value: true
+
+  - name: float_default_value
+    given:
+      config: |
+        name: myapp
+      schema: |
+        type: object
+        properties:
+          name:
+            type: string
+          timeout:
+            type: number
+            default: 30.5
+    when:
+      access: timeout
+    then:
+      value: 30.5
+
+  - name: null_value_uses_default_when_null_disallowed
+    given:
+      config: |
+        value: null
+      schema: |
+        type: object
+        properties:
+          value:
+            type: string
+            default: fallback
+    when:
+      access: value
+    then:
+      value: fallback
+
+  - name: null_value_preserved_when_null_allowed
+    given:
+      config: |
+        value: null
+      schema: |
+        type: object
+        properties:
+          value:
+            type:
+              - string
+              - "null"
+            default: fallback
+    when:
+      access: value
+    then:
+      value: null
+
+  - name: object_default_value
+    given:
+      config: |
+        name: myapp
+      schema: |
+        type: object
+        properties:
+          name:
+            type: string
+          logging:
+            type: object
+            default:
+              level: info
+              format: json
+    when:
+      access: logging
+    then:
+      value:
+        level: info
+        format: json
+
+  - name: array_default_value
+    given:
+      config: |
+        name: myapp
+      schema: |
+        type: object
+        properties:
+          name:
+            type: string
+          tags:
+            type: array
+            default:
+              - default
+              - tag
+    when:
+      access: tags
+    then:
+      value:
+        - default
+        - tag

--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -303,6 +303,9 @@ class RustDriver(Driver):
     def load_schema(self, yaml_content: str) -> Any:
         return self.Schema.from_yaml(yaml_content)
 
+    def set_schema(self, config: Any, schema: Any) -> None:
+        config.set_schema(schema)
+
     def validate(self, config: Any, schema: Any) -> None:
         config.validate(schema)
 
@@ -412,6 +415,9 @@ class PythonDriver(Driver):
 
     def load_schema(self, yaml_content: str) -> Any:
         return self.Schema.from_yaml(yaml_content)
+
+    def set_schema(self, config: Any, schema: Any) -> None:
+        config.set_schema(schema)
 
     def validate(self, config: Any, schema: Any) -> None:
         config.validate(schema)
@@ -829,6 +835,11 @@ def run_test(driver: Driver, test: TestCase, suite_name: str) -> TestResult:
 
         elif "access" in test.when:
             path = test.when["access"]
+            # If a schema is provided, attach it for default value lookup
+            schema_yaml = test.given.get("schema", "")
+            if schema_yaml:
+                schema = driver.load_schema(schema_yaml)
+                driver.set_schema(config, schema)
             try:
                 result = driver.access(config, path)
             except Exception as e:


### PR DESCRIPTION
## Summary

When accessing a config path that doesn't exist but has a `default` in the attached JSON Schema, return the schema default instead of raising `PathNotFoundError`. Also handles null values: if the config value is explicitly `null` and the schema doesn't allow null but has a default, use the schema default.

Value precedence: config value > resolver default > schema default

## Related Issue

Fixes #2

## Spec / ADR

- [FEAT-004: Schema Validation](docs/specs/features/FEAT-004-schema-validation.md) - defines the "Default Values" behavior (lines 171-191)
- [ADR-007: Schema and Validation](docs/adr/ADR-007-schema-validation.md) - two-phase validation design

## Changes

- [x] Rust core (`crates/holoconf-core/`)
- [x] Python bindings (`crates/holoconf-python/`)
- [x] CLI (`crates/holoconf-cli/`)
- [x] Documentation (`docs/`)
- [x] Tests

### Details

**Core (`holoconf-core`)**
- Added `Schema.get_default(path)` to retrieve default values from nested schema definitions
- Added `Schema.allows_null(path)` to check if a path permits null values
- Added `Config.set_schema()` and `Config.get_schema()` for schema attachment
- Modified `Config.get()` to fall back to schema defaults when path not found or null-but-disallowed
- Updated `validate()`, `validate_raw()`, `validate_collect()` to accept optional schema parameter

**Python bindings (`holoconf-python`)**
- Added `schema` parameter to `Config.load()` and `Config.required()`
- Added `set_schema()` and `get_schema()` methods
- Updated validate methods to accept optional schema

**CLI (`holoconf-cli`)**
- Added `--schema` flag to `dump` and `get` commands
- Enhanced `validate` command to show all errors with paths

**Documentation**
- Updated `docs/guide/validation.md` with Loading with Schema section
- Added `--schema` option docs to CLI reference

## Checklist

- [x] `make check` passes
- [x] Added/updated tests
- [x] Updated CHANGELOG.md (if user-facing)
- [x] Updated type stubs (if Python API changed)
- [x] Updated docs (if user-facing)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)