### PR TITLE
feat: add glob pattern support for config file loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Glob Pattern Support
+- **Glob patterns in `Config.load()` and `Config.optional()`** - Load and merge multiple files matching a pattern
+  - `Config.load("config/*.yaml")` - Load all matching files, error if none match
+  - `Config.optional("config/*.yaml")` - Load all matching files, empty config if none match
+- **Supported patterns**: `*` (any chars), `**` (recursive), `?` (single char), `[abc]` (char class)
+- **Alphabetical merge order** - Files are sorted before merging, so `00-base.yaml` loads before `99-local.yaml`
+
 #### Schema Default Values
 - **Schema defaults for missing paths** - When a schema is attached to a config, accessing a missing path returns the schema default instead of `PathNotFoundError`
   - `Config.load("config.yaml", schema="schema.yaml")` - Load with schema attached

--- a/crates/holoconf-core/Cargo.toml
+++ b/crates/holoconf-core/Cargo.toml
@@ -28,6 +28,7 @@ indexmap.workspace = true
 jsonschema.workspace = true
 regex.workspace = true
 base64.workspace = true
+glob = "0.3"
 # Optional HTTP support
 ureq = { version = "3.0", optional = true }
 

--- a/docs/guide/merging.md
+++ b/docs/guide/merging.md
@@ -221,4 +221,97 @@ config/
     }
     ```
 
+## Glob Patterns
+
+When loading configurations from multiple files, you can use glob patterns to automatically match and merge files:
+
+=== "Python"
+
+    ```python
+    from holoconf import Config
+
+    # Load all YAML files in config/ directory
+    config = Config.load("config/*.yaml")
+
+    # Load recursively from nested directories
+    config = Config.load("config/**/*.yaml")
+    ```
+
+=== "Rust"
+
+    ```rust
+    use holoconf::Config;
+
+    fn main() -> Result<(), holoconf::Error> {
+        // Load all YAML files in config/ directory
+        let config = Config::load("config/*.yaml")?;
+
+        // Load recursively from nested directories
+        let config = Config::load("config/**/*.yaml")?;
+
+        Ok(())
+    }
+    ```
+
+### Supported Patterns
+
+| Pattern | Matches |
+|---------|---------|
+| `*` | Any sequence of characters (except `/`) |
+| `**` | Any sequence of directories |
+| `?` | Any single character |
+| `[abc]` | Any character in the set |
+| `[a-z]` | Any character in the range |
+
+### Merge Order
+
+Files matching a glob pattern are **sorted alphabetically** before merging. This means:
+
+- `00-base.yaml` is loaded before `10-override.yaml`
+- `a.yaml` is loaded before `b.yaml`
+- `config/base.yaml` is loaded before `config/sub/override.yaml`
+
+Use numeric prefixes to control the merge order:
+
+```
+config/
+├── 00-base.yaml       # Loaded first (base settings)
+├── 10-database.yaml   # Loaded second
+├── 20-logging.yaml    # Loaded third
+└── 99-local.yaml      # Loaded last (highest priority)
+```
+
+### Required vs Optional Globs
+
+- **`Config.load("pattern")`**: At least one file must match. Returns an error if no files match.
+- **`Config.optional("pattern")`**: Returns an empty config if no files match.
+
+=== "Python"
+
+    ```python
+    from holoconf import Config
+
+    # Error if no files match
+    config = Config.load("config/*.yaml")
+
+    # Empty config if no files match
+    overrides = Config.optional("overrides/*.yaml")
+    ```
+
+=== "Rust"
+
+    ```rust
+    use holoconf::Config;
+
+    fn main() -> Result<(), holoconf::Error> {
+        // Error if no files match
+        let config = Config::load("config/*.yaml")?;
+
+        // Empty config if no files match
+        let overrides = Config::optional("overrides/*.yaml")?;
+
+        Ok(())
+    }
+    ```
+
 See [ADR-004 Config Merging](../adr/ADR-004-config-merging.md) for the design rationale.

--- a/tests/acceptance/merging/glob_patterns.yaml
+++ b/tests/acceptance/merging/glob_patterns.yaml
@@ -1,0 +1,173 @@
+suite: glob_patterns
+description: Glob pattern support for loading multiple config files
+
+tests:
+  - name: glob_star_pattern_merges_alphabetically
+    given:
+      files:
+        config/a.yaml: |
+          key: a
+          from_a: true
+        config/b.yaml: |
+          key: b
+          from_b: true
+        config/c.yaml: |
+          key: c
+          from_c: true
+      config_glob: "config/*.yaml"
+    when:
+      access: key
+    then:
+      # Files sorted alphabetically: a.yaml, b.yaml, c.yaml
+      # c.yaml is last, so its value wins
+      value: c
+
+  - name: glob_preserves_unoverwritten_keys
+    given:
+      files:
+        config/a.yaml: |
+          key: a
+          from_a: true
+        config/b.yaml: |
+          key: b
+          from_b: true
+      config_glob: "config/*.yaml"
+    when:
+      access: from_a
+    then:
+      value: true
+
+  - name: glob_double_star_recursive
+    given:
+      files:
+        config/base.yaml: |
+          value: base
+          from_base: true
+        config/sub/override.yaml: |
+          value: override
+          from_sub: true
+        config/sub/deep/more.yaml: |
+          value: deep
+          from_deep: true
+      config_glob: "config/**/*.yaml"
+    when:
+      access: value
+    then:
+      # Alphabetical: base.yaml, sub/deep/more.yaml, sub/override.yaml
+      # sub/override.yaml is last alphabetically, so its value wins
+      value: override
+
+  - name: glob_question_mark_single_char
+    given:
+      files:
+        config/a.yaml: |
+          key: a
+        config/b.yaml: |
+          key: b
+        config/long_name.yaml: |
+          key: long
+      config_glob: "config/?.yaml"
+    when:
+      access: key
+    then:
+      # Only matches single-character names: a.yaml, b.yaml
+      # long_name.yaml is not matched
+      value: b
+
+  - name: glob_character_class
+    given:
+      files:
+        config/a.yaml: |
+          matched: true
+          key: a
+        config/b.yaml: |
+          matched: true
+          key: b
+        config/c.yaml: |
+          matched: false
+          key: c
+      config_glob: "config/[ab].yaml"
+    when:
+      access: key
+    then:
+      # Only matches a.yaml and b.yaml
+      value: b
+
+  - name: glob_required_no_matches_errors
+    given:
+      files: {}
+      config_glob: "nonexistent/*.yaml"
+      glob_required: true
+    when:
+      load: true
+    then:
+      error:
+        message_contains: "No files matched"
+
+  - name: glob_optional_no_matches_returns_empty
+    given:
+      files: {}
+      config_glob: "nonexistent/*.yaml"
+      glob_required: false
+    when:
+      export: dict
+      resolve: true
+    then:
+      value: {}
+
+  - name: glob_deep_merge
+    given:
+      files:
+        config/base.yaml: |
+          database:
+            host: localhost
+            port: 5432
+            pool:
+              min: 5
+              max: 20
+        config/override.yaml: |
+          database:
+            host: prod-db
+            pool:
+              max: 100
+      config_glob: "config/*.yaml"
+    when:
+      access: database
+    then:
+      value:
+        host: prod-db
+        port: 5432
+        pool:
+          min: 5
+          max: 100
+
+  - name: glob_with_numeric_prefixes
+    given:
+      files:
+        config/00-base.yaml: |
+          priority: 0
+        config/10-middle.yaml: |
+          priority: 10
+        config/99-last.yaml: |
+          priority: 99
+      config_glob: "config/*.yaml"
+    when:
+      access: priority
+    then:
+      # Alphabetical order: 00-base, 10-middle, 99-last
+      # 99-last.yaml is last, so its value wins
+      value: 99
+
+  - name: glob_empty_file_does_not_break
+    given:
+      files:
+        config/a.yaml: |
+          key: a
+        config/empty.yaml: ""
+        config/z.yaml: |
+          key: z
+      config_glob: "config/*.yaml"
+    when:
+      access: key
+    then:
+      value: z


### PR DESCRIPTION
## Summary

Add glob pattern support to `Config.load()` and `Config.optional()` so they can expand patterns like `config/*.yaml` and merge matching files alphabetically. Supports `*`, `**`, `?`, and character classes `[abc]`.

## Related Issue

Fixes #7

## Spec / ADR

Implements [FEAT-003: Configuration Merging](docs/specs/features/FEAT-003-config-merging.md) (glob section)

## Changes

- [x] Rust core (`crates/holoconf-core/`)
- [ ] Python bindings (`crates/holoconf-python/`)
- [ ] CLI (`crates/holoconf-cli/`)
- [x] Documentation (`docs/`)
- [x] Tests

## Checklist

- [x] `make check` passes
- [x] Added/updated tests
- [x] Updated CHANGELOG.md (if user-facing)
- [ ] Updated type stubs (if Python API changed)
- [x] Updated docs (if user-facing)