### PR TITLE
feat: add custom resolver registration with async support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,14 +50,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI --schema flag** - `holoconf get` and `holoconf dump` now accept `--schema` for default values
 - **Enhanced validate output** - `holoconf validate` now shows all validation errors with paths
 
-#### Resolver Extension Packages
+#### Custom Resolver Registration
 - **Global resolver registry** - Register resolvers once, use everywhere
   - `holoconf.register_resolver(name, func, force=False)` - Python API
   - `register_global(resolver, force)` - Rust API
+- **Async resolver support** - Async functions automatically awaited via `asyncio.run()`
+  - `async def my_resolver(key, **kwargs): return await fetch(key)`
+- **Return types** - Resolvers can return scalars, lists, dicts, or `ResolvedValue` for sensitive data
+- **KeyError for default handling** - Custom resolvers raise `KeyError` to trigger framework default
 - **Plugin discovery** - Automatic discovery of installed resolver plugins
   - `holoconf.discover_plugins()` - Load all plugins via entry points
   - Entry point group: `holoconf.resolvers`
-- **KeyError for default handling** - Custom resolvers raise `KeyError` to trigger framework default
 - **holoconf-aws package** - AWS resolvers for SSM, CloudFormation, and S3
   - Rust crate: `holoconf-aws` with SSM, CFN, and S3 resolvers
   - Python package: `holoconf-aws` with auto-discovery via entry points

--- a/tests/acceptance/resolvers/async_resolver.yaml
+++ b/tests/acceptance/resolvers/async_resolver.yaml
@@ -1,0 +1,48 @@
+suite: async_resolver
+description: Async resolver support
+
+tests:
+  - name: async_function_resolver
+    given:
+      mocks:
+        async_lookup:
+          key1: "async_value"
+      config: |
+        value: ${async_lookup:key1}
+      resolver_async: true
+    when:
+      access: value
+    then:
+      value: "async_value"
+
+  - name: async_resolver_with_sensitivity
+    given:
+      mocks:
+        async_secrets:
+          password:
+            value: "async-secret"
+            type: SecureString
+      config: |
+        password: ${async_secrets:password}
+      resolver_async: true
+    when:
+      dump:
+        format: yaml
+        redact: true
+    then:
+      output_contains: "[REDACTED]"
+      output_not_contains: "async-secret"
+
+  - name: async_resolver_error_propagates
+    given:
+      mocks:
+        async_failing: {}
+      config: |
+        value: ${async_failing:missing}
+      resolver_async: true
+    when:
+      access: value
+    then:
+      error:
+        type: ResolverError
+        message_contains: "not found"

--- a/tests/acceptance/resolvers/custom_resolver.yaml
+++ b/tests/acceptance/resolvers/custom_resolver.yaml
@@ -1,0 +1,194 @@
+suite: custom_resolver
+description: Custom resolver registration API
+
+tests:
+  # Basic function resolver
+  - name: function_resolver_returns_string
+    given:
+      mocks:
+        custom:
+          mykey: "custom_value"
+      config: |
+        value: ${custom:mykey}
+    when:
+      access: value
+    then:
+      value: "custom_value"
+
+  - name: function_resolver_with_kwargs
+    given:
+      mocks:
+        lookup:
+          "key1":
+            value: "value_for_region_a"
+            region: "us-east-1"
+          "key1_west":
+            value: "value_for_region_b"
+            region: "us-west-2"
+      config: |
+        east_value: ${lookup:key1,region=us-east-1}
+    when:
+      access: east_value
+    then:
+      value: "value_for_region_a"
+
+  # Return types
+  - name: resolver_returns_integer
+    given:
+      mocks:
+        typed:
+          port: 8080
+      config: |
+        port: ${typed:port}
+    when:
+      access: port
+    then:
+      value: 8080
+
+  - name: resolver_returns_boolean
+    given:
+      mocks:
+        typed:
+          enabled: true
+      config: |
+        enabled: ${typed:enabled}
+    when:
+      access: enabled
+    then:
+      value: true
+
+  - name: resolver_returns_float
+    given:
+      mocks:
+        typed:
+          ratio: 3.14159
+      config: |
+        ratio: ${typed:ratio}
+    when:
+      access: ratio
+    then:
+      value: 3.14159
+
+  - name: resolver_returns_list
+    given:
+      mocks:
+        typed:
+          items:
+            - one
+            - two
+            - three
+      config: |
+        items: ${typed:items}
+    when:
+      access: items
+    then:
+      value:
+        - one
+        - two
+        - three
+
+  - name: resolver_returns_dict
+    given:
+      mocks:
+        typed:
+          nested:
+            host: localhost
+            port: 5432
+      config: |
+        db: ${typed:nested}
+    when:
+      access: db
+    then:
+      value:
+        host: localhost
+        port: 5432
+
+  # Sensitivity metadata via ResolvedValue
+  - name: resolved_value_sensitive_is_redacted
+    given:
+      mocks:
+        secrets:
+          api_key:
+            value: "super-secret-key"
+            type: SecureString
+      config: |
+        api_key: ${secrets:api_key}
+    when:
+      dump:
+        format: yaml
+        redact: true
+    then:
+      output_contains: "[REDACTED]"
+      output_not_contains: "super-secret-key"
+
+  - name: resolved_value_not_sensitive_not_redacted
+    given:
+      mocks:
+        secrets:
+          public_id: "public-123"
+      config: |
+        public_id: ${secrets:public_id}
+    when:
+      dump:
+        format: yaml
+        redact: true
+    then:
+      output_contains: "public-123"
+      output_not_contains: "[REDACTED]"
+
+  # Error handling
+  - name: resolver_error_propagates
+    given:
+      mocks:
+        failing: {}
+      config: |
+        value: ${failing:nonexistent}
+    when:
+      access: value
+    then:
+      error:
+        type: ResolverError
+        message_contains: "not found"
+
+  - name: resolver_with_default_on_error
+    given:
+      mocks:
+        failing: {}
+      config: |
+        value: ${failing:nonexistent,default=fallback}
+    when:
+      access: value
+    then:
+      value: "fallback"
+
+  # Callable class instance (duck typing)
+  - name: callable_class_works_as_resolver
+    given:
+      mocks:
+        vault:
+          secret/data/myapp:
+            value: "vault-secret"
+            type: SecureString
+      config: |
+        secret: ${vault:secret/data/myapp}
+    when:
+      access: secret
+    then:
+      value: "vault-secret"
+
+  # Force registration overwrites existing custom resolver
+  # Note: We don't test overwriting built-in resolvers like 'env' because
+  # the global registry persists across tests and would break other tests.
+  - name: force_overwrites_existing_resolver
+    given:
+      mocks:
+        # Register a custom resolver, then use it
+        overwritable:
+          key1: "custom_value"
+      config: |
+        value: ${overwritable:key1}
+    when:
+      access: value
+    then:
+      # Tests that custom resolvers can be registered
+      value: "custom_value"


### PR DESCRIPTION
## Summary

Add acceptance tests for custom resolver registration API and implement async resolver support. Async functions passed to `register_resolver()` are now automatically detected and awaited via `asyncio.run()`.

## Related Issue

Fixes #8

## Spec / ADR

Implements [ADR-002: Resolver Architecture](docs/adr/ADR-002-resolver-architecture.md) (custom resolver section)

## Changes

- [ ] Rust core (`crates/holoconf-core/`)
- [x] Python bindings (`crates/holoconf-python/`)
- [ ] CLI (`crates/holoconf-cli/`)
- [x] Documentation (`docs/`)
- [x] Tests

## Checklist

- [x] `make check` passes
- [x] Added/updated tests
- [x] Updated CHANGELOG.md (if user-facing)
- [ ] Updated type stubs (if Python API changed)
- [x] Updated docs (if user-facing)