### PR TITLE
feat: implement HTTP resolver with full functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI --schema flag** - `holoconf get` and `holoconf dump` now accept `--schema` for default values
 - **Enhanced validate output** - `holoconf validate` now shows all validation errors with paths
 
+#### HTTP Resolver
+- **Full HTTP resolver implementation** - Fetch configuration from remote URLs
+  - Disabled by default for security - enable with `allow_http=True`
+  - URL allowlist support for restricting which URLs can be fetched
+  - Parse modes: `auto`, `yaml`, `json`, `text`, `binary`
+  - Configurable timeout via `timeout=<seconds>` parameter
+  - Custom header support via `header=Name:Value` parameter
+  - Auto-detection from Content-Type and URL extension
+- **Security controls**:
+  - `allow_http` option to explicitly enable HTTP resolver
+  - `http_allowlist` option to restrict accessible URLs with glob patterns
+- **Example usage**:
+  ```yaml
+  config: ${http:https://config.example.com/settings.yaml}
+  api_key: ${http:https://api.example.com/key,header=Authorization:Bearer token}
+  ```
+
 #### Custom Resolver Registration
 - **Global resolver registry** - Register resolvers once, use everywhere
   - `holoconf.register_resolver(name, func, force=False)` - Python API

--- a/crates/holoconf-core/Cargo.toml
+++ b/crates/holoconf-core/Cargo.toml
@@ -34,3 +34,4 @@ ureq = { version = "3.0", optional = true }
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+mockito = "1.2"

--- a/crates/holoconf-core/src/error.rs
+++ b/crates/holoconf-core/src/error.rs
@@ -273,6 +273,54 @@ impl Error {
         }
     }
 
+    /// Create an HTTP request failed error
+    pub fn http_request_failed(
+        url: impl Into<String>,
+        message: impl Into<String>,
+        config_path: Option<String>,
+    ) -> Self {
+        let url_str = url.into();
+        Self {
+            kind: ErrorKind::Resolver(ResolverErrorKind::HttpError {
+                url: url_str.clone(),
+                status: None,
+            }),
+            path: config_path,
+            source_location: None,
+            help: Some(format!(
+                "Check that the URL '{}' is accessible and returns valid content",
+                url_str
+            )),
+            cause: Some(message.into()),
+        }
+    }
+
+    /// Create an HTTP not in allowlist error
+    pub fn http_not_in_allowlist(
+        url: impl Into<String>,
+        allowlist: &[String],
+        config_path: Option<String>,
+    ) -> Self {
+        let url_str = url.into();
+        let allowlist_str = if allowlist.is_empty() {
+            "(empty)".to_string()
+        } else {
+            allowlist.join(", ")
+        };
+        Self {
+            kind: ErrorKind::Resolver(ResolverErrorKind::HttpNotAllowed {
+                url: url_str.clone(),
+            }),
+            path: config_path,
+            source_location: None,
+            help: Some(format!(
+                "Add '{}' to the http_allowlist, or use a pattern that matches it.\nCurrent allowlist: {}",
+                url_str, allowlist_str
+            )),
+            cause: None,
+        }
+    }
+
     /// Create an internal error (bug in holoconf)
     pub fn internal(message: impl Into<String>) -> Self {
         Self {

--- a/docs/guide/resolvers.md
+++ b/docs/guide/resolvers.md
@@ -115,7 +115,70 @@ Fetch configuration from HTTP endpoints.
 feature_flags: ${http:https://config.example.com/flags.json}
 # With fallback if request fails
 remote_config: ${http:https://api.example.com/config,default={}}
+# With authentication header
+private_config: ${http:https://api.example.com/config,header=Authorization:Bearer token}
+# With explicit parse mode
+raw_data: ${http:https://api.example.com/data,parse=text}
 ```
+
+#### Enabling HTTP Resolver
+
+=== "Python"
+
+    ```python
+    from holoconf import Config
+
+    # Enable HTTP resolver
+    config = Config.from_file("config.yaml", allow_http=True)
+
+    # With URL allowlist for additional security
+    config = Config.from_file(
+        "config.yaml",
+        allow_http=True,
+        http_allowlist=["https://config.example.com/*", "https://*.internal.com/*"]
+    )
+    ```
+
+=== "Rust"
+
+    ```rust
+    use holoconf::Config;
+
+    let config = Config::builder()
+        .allow_http(true)
+        .http_allowlist(vec!["https://config.example.com/*"])
+        .load("config.yaml")?;
+    ```
+
+#### HTTP Resolver Options
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `parse=auto` | Auto-detect from Content-Type or URL extension (default) | `${http:https://example.com/config}` |
+| `parse=yaml` | Parse response as YAML | `${http:https://example.com/config,parse=yaml}` |
+| `parse=json` | Parse response as JSON | `${http:https://example.com/config,parse=json}` |
+| `parse=text` | Return response as text | `${http:https://example.com/data,parse=text}` |
+| `parse=binary` | Return response as raw bytes | `${http:https://example.com/cert,parse=binary}` |
+| `timeout=30` | Request timeout in seconds (default: 30) | `${http:https://example.com/config,timeout=60}` |
+| `header=Name:Value` | Add custom HTTP header | `${http:https://api.com/config,header=Authorization:Bearer token}` |
+
+#### URL Allowlist Patterns
+
+The URL allowlist supports glob-style patterns:
+
+| Pattern | Matches |
+|---------|---------|
+| `https://example.com/*` | Any path on example.com |
+| `https://*.example.com/*` | Any subdomain of example.com |
+| `https://api.example.com/config/*` | Specific path prefix |
+
+#### Security Best Practices
+
+1. **Keep HTTP disabled by default** - Only enable when needed
+2. **Use URL allowlist** - Restrict which URLs can be fetched
+3. **Use HTTPS** - Always use HTTPS for sensitive configuration
+4. **Set appropriate timeouts** - Prevent hanging on slow responses
+5. **Use authentication** - Add authorization headers for private endpoints
 
 ## Lazy Resolution
 

--- a/tests/acceptance/resolvers/http_resolver.yaml
+++ b/tests/acceptance/resolvers/http_resolver.yaml
@@ -2,6 +2,9 @@ suite: http_resolver
 description: HTTP resolver behavior (disabled by default for security)
 
 tests:
+  # === Security: Disabled by Default ===
+  # These tests verify the HTTP resolver is disabled by default (no actual HTTP calls)
+
   - name: http_resolver_disabled_by_default
     given:
       config: |
@@ -10,4 +13,31 @@ tests:
       access: remote
     then:
       error:
+        type: ResolverError
         message_contains: "HTTP resolver is disabled"
+
+  - name: http_resolver_disabled_error_includes_help
+    given:
+      config: |
+        remote: ${http:https://config.internal/app.yaml}
+    when:
+      access: remote
+    then:
+      error:
+        message_contains: "allow_http"
+
+  - name: http_no_url_error
+    given:
+      config: |
+        bad: ${http:}
+    when:
+      access: bad
+    then:
+      error:
+        type: ResolverError
+        message_contains: "requires a URL"
+
+  # Note: Tests for actual HTTP functionality (fetching, parsing, headers, timeouts,
+  # allowlists) require HTTP mocking and are implemented as Rust unit tests in
+  # crates/holoconf-core/src/resolver.rs using the mockito crate.
+  # See issue #3 for test coverage details.


### PR DESCRIPTION
## Summary

Implements the HTTP resolver for fetching configuration from remote URLs. The resolver is disabled by default for security and requires explicit opt-in via `allow_http=true`. Supports URL allowlists, multiple parse modes, custom headers, and configurable timeouts.

## Related Issue

Fixes #6
Fixes #3 (test coverage)
Future enhancements: #19 (TLS/proxy support)

## Spec / ADR

- [FEAT-002 Core Resolvers](docs/specs/features/FEAT-002-core-resolvers.md) - HTTP resolver specification

## Changes

- [x] Rust core (`crates/holoconf-core/`)
- [ ] Python bindings (`crates/holoconf-python/`)
- [ ] CLI (`crates/holoconf-cli/`)
- [x] Documentation (`docs/`)
- [x] Tests

## Checklist

- [x] `make check` passes
- [x] Added/updated tests
- [x] Updated CHANGELOG.md (if user-facing)
- [ ] Updated type stubs (if Python API changed)
- [x] Updated docs (if user-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)