### PR TITLE
feat: add two-tier configure API for AWS resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Security:** Warn users about weak ZipCrypto encryption (prefer AES or GPG)
   - Requires `archive` feature flag (enabled by default in Python package)
   - Feature adds dependencies: `tar`, `zip`, `flate2`, `infer`
+- **AWS Resolver Configuration API**: Two-tier configuration system for AWS resolvers (#27)
+  - Global configuration: `holoconf_aws.configure(region="us-east-1", profile="prod")` sets defaults for all AWS services
+  - Service-specific configuration: `holoconf_aws.s3(endpoint="http://localhost:5000")` overrides for individual services
+  - `holoconf_aws.reset()` clears all configuration and client cache (useful for test isolation)
+  - Four-level precedence: resolver kwargs > service config > global config > AWS SDK defaults
+  - All AWS resolvers now support `endpoint=` kwarg for per-call endpoint overrides
+  - Enables testing with moto/LocalStack via custom endpoint URLs
+  - Configuration is additive: calling `configure(region=None)` leaves existing values unchanged
+  - See [Configuration API guide](guide/resolvers-aws.md#configuration-api) for full details
 
 ### Changed
 - **BREAKING: File Resolver Auto-Parsing Removed**: File resolver no longer automatically parses JSON/YAML based on file extension (#26)

--- a/crates/holoconf-aws-python/src/lib.rs
+++ b/crates/holoconf-aws-python/src/lib.rs
@@ -98,6 +98,93 @@ fn register_all(force: bool) -> PyResult<()> {
     Ok(())
 }
 
+/// Configure global defaults for all AWS services.
+///
+/// Sets default region and profile that apply to all AWS services (S3, SSM, CloudFormation).
+/// These can be overridden by service-specific configuration or per-resolver kwargs.
+///
+/// Args:
+///     region: Default AWS region (e.g., "us-east-1")
+///     profile: Default AWS profile name
+///
+/// Example:
+///     >>> import holoconf_aws
+///     >>> holoconf_aws.configure(region="us-east-1", profile="prod")
+#[pyfunction]
+#[pyo3(signature = (region=None, profile=None))]
+fn configure(region: Option<String>, profile: Option<String>) {
+    holoconf_aws::configure(region, profile);
+}
+
+/// Configure S3-specific defaults.
+///
+/// Overrides global configuration for the S3 resolver.
+///
+/// Args:
+///     endpoint: S3 endpoint URL (for moto/LocalStack, e.g., "http://localhost:5000")
+///     region: AWS region (overrides global region)
+///     profile: AWS profile name (overrides global profile)
+///
+/// Example:
+///     >>> import holoconf_aws
+///     >>> holoconf_aws.s3(endpoint="http://localhost:5000", region="us-west-2")
+#[pyfunction]
+#[pyo3(signature = (endpoint=None, region=None, profile=None))]
+fn s3(endpoint: Option<String>, region: Option<String>, profile: Option<String>) {
+    holoconf_aws::configure_s3(endpoint, region, profile);
+}
+
+/// Configure SSM-specific defaults.
+///
+/// Overrides global configuration for the SSM resolver.
+///
+/// Args:
+///     endpoint: SSM endpoint URL (for moto/LocalStack)
+///     region: AWS region (overrides global region)
+///     profile: AWS profile name (overrides global profile)
+///
+/// Example:
+///     >>> import holoconf_aws
+///     >>> holoconf_aws.ssm(endpoint="http://localhost:5001")
+#[pyfunction]
+#[pyo3(signature = (endpoint=None, region=None, profile=None))]
+fn ssm(endpoint: Option<String>, region: Option<String>, profile: Option<String>) {
+    holoconf_aws::configure_ssm(endpoint, region, profile);
+}
+
+/// Configure CloudFormation-specific defaults.
+///
+/// Overrides global configuration for the CloudFormation resolver.
+///
+/// Args:
+///     endpoint: CloudFormation endpoint URL (for moto/LocalStack)
+///     region: AWS region (overrides global region)
+///     profile: AWS profile name (overrides global profile)
+///
+/// Example:
+///     >>> import holoconf_aws
+///     >>> holoconf_aws.cfn(profile="testing")
+#[pyfunction]
+#[pyo3(signature = (endpoint=None, region=None, profile=None))]
+fn cfn(endpoint: Option<String>, region: Option<String>, profile: Option<String>) {
+    holoconf_aws::configure_cfn(endpoint, region, profile);
+}
+
+/// Reset all configuration and clear the client cache.
+///
+/// Clears all global and service-specific configuration, and removes all cached AWS clients.
+/// Useful for test isolation.
+///
+/// Example:
+///     >>> import holoconf_aws
+///     >>> holoconf_aws.s3(endpoint="http://localhost:5000")
+///     >>> # ... run tests ...
+///     >>> holoconf_aws.reset()  # Clean up for next test
+#[pyfunction]
+fn reset() {
+    holoconf_aws::reset();
+}
+
 /// Python module for holoconf AWS resolvers
 #[pymodule]
 fn _holoconf_aws(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -105,5 +192,10 @@ fn _holoconf_aws(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(register_cfn, m)?)?;
     m.add_function(wrap_pyfunction!(register_s3, m)?)?;
     m.add_function(wrap_pyfunction!(register_all, m)?)?;
+    m.add_function(wrap_pyfunction!(configure, m)?)?;
+    m.add_function(wrap_pyfunction!(s3, m)?)?;
+    m.add_function(wrap_pyfunction!(ssm, m)?)?;
+    m.add_function(wrap_pyfunction!(cfn, m)?)?;
+    m.add_function(wrap_pyfunction!(reset, m)?)?;
     Ok(())
 }

--- a/crates/holoconf-aws/src/lib.rs
+++ b/crates/holoconf-aws/src/lib.rs
@@ -96,10 +96,16 @@ static CFN_CONFIG: Lazy<RwLock<CfnConfig>> = Lazy::new(Default::default);
 /// Sets default region and profile for all AWS services (S3, SSM, CloudFormation).
 /// These can be overridden by service-specific configuration or per-resolver kwargs.
 ///
+/// Configuration precedence (highest to lowest):
+/// 1. Resolver kwargs in config file (e.g., `${s3:bucket/file,region=us-east-1}`)
+/// 2. Service-specific configuration (`configure_s3()`, `configure_ssm()`, `configure_cfn()`)
+/// 3. Global configuration (`configure()`)
+/// 4. AWS SDK defaults (environment variables, credentials file)
+///
 /// # Arguments
 ///
-/// * `region` - Default AWS region
-/// * `profile` - Default AWS profile name
+/// * `region` - Default AWS region (e.g., "us-east-1"). Pass `None` to leave unchanged.
+/// * `profile` - Default AWS profile name. Pass `None` to leave unchanged.
 ///
 /// # Example
 ///
@@ -108,6 +114,9 @@ static CFN_CONFIG: Lazy<RwLock<CfnConfig>> = Lazy::new(Default::default);
 ///
 /// // Set global defaults
 /// holoconf_aws::configure(Some("us-east-1".to_string()), Some("prod".to_string()));
+///
+/// // Update only region, profile remains unchanged
+/// holoconf_aws::configure(Some("us-west-2".to_string()), None);
 /// ```
 pub fn configure(region: Option<String>, profile: Option<String>) {
     let mut config = GLOBAL_CONFIG.write().unwrap();
@@ -125,9 +134,9 @@ pub fn configure(region: Option<String>, profile: Option<String>) {
 ///
 /// # Arguments
 ///
-/// * `endpoint` - S3 endpoint URL (for moto/LocalStack)
-/// * `region` - AWS region
-/// * `profile` - AWS profile name
+/// * `endpoint` - S3 endpoint URL (for moto/LocalStack, e.g., "http://localhost:5000"). Pass `None` to leave unchanged.
+/// * `region` - AWS region (overrides global region). Pass `None` to leave unchanged.
+/// * `profile` - AWS profile name (overrides global profile). Pass `None` to leave unchanged.
 ///
 /// # Example
 ///
@@ -160,9 +169,9 @@ pub fn configure_s3(endpoint: Option<String>, region: Option<String>, profile: O
 ///
 /// # Arguments
 ///
-/// * `endpoint` - SSM endpoint URL (for moto/LocalStack)
-/// * `region` - AWS region
-/// * `profile` - AWS profile name
+/// * `endpoint` - SSM endpoint URL (for moto/LocalStack, e.g., "http://localhost:5001"). Pass `None` to leave unchanged.
+/// * `region` - AWS region (overrides global region). Pass `None` to leave unchanged.
+/// * `profile` - AWS profile name (overrides global profile). Pass `None` to leave unchanged.
 ///
 /// # Example
 ///
@@ -195,9 +204,9 @@ pub fn configure_ssm(endpoint: Option<String>, region: Option<String>, profile: 
 ///
 /// # Arguments
 ///
-/// * `endpoint` - CloudFormation endpoint URL (for moto/LocalStack)
-/// * `region` - AWS region
-/// * `profile` - AWS profile name
+/// * `endpoint` - CloudFormation endpoint URL (for moto/LocalStack, e.g., "http://localhost:5002"). Pass `None` to leave unchanged.
+/// * `region` - AWS region (overrides global region). Pass `None` to leave unchanged.
+/// * `profile` - AWS profile name (overrides global profile). Pass `None` to leave unchanged.
 ///
 /// # Example
 ///
@@ -250,6 +259,93 @@ pub fn reset() {
     client_cache::clear();
 }
 
+/// Helper trait to access service-specific configuration.
+trait ServiceConfig {
+    fn endpoint(&self) -> &Option<String>;
+    fn region(&self) -> &Option<String>;
+    fn profile(&self) -> &Option<String>;
+}
+
+impl ServiceConfig for S3Config {
+    fn endpoint(&self) -> &Option<String> {
+        &self.endpoint
+    }
+    fn region(&self) -> &Option<String> {
+        &self.region
+    }
+    fn profile(&self) -> &Option<String> {
+        &self.profile
+    }
+}
+
+impl ServiceConfig for SsmConfig {
+    fn endpoint(&self) -> &Option<String> {
+        &self.endpoint
+    }
+    fn region(&self) -> &Option<String> {
+        &self.region
+    }
+    fn profile(&self) -> &Option<String> {
+        &self.profile
+    }
+}
+
+impl ServiceConfig for CfnConfig {
+    fn endpoint(&self) -> &Option<String> {
+        &self.endpoint
+    }
+    fn region(&self) -> &Option<String> {
+        &self.region
+    }
+    fn profile(&self) -> &Option<String> {
+        &self.profile
+    }
+}
+
+/// Generic resolver for configuration with precedence.
+///
+/// Precedence: kwargs > service config > global config
+///
+/// This function minimizes allocations by:
+/// 1. Releasing locks before cloning (reduces lock contention)
+/// 2. Only cloning values that will actually be used
+fn resolve_config_with_precedence<T: ServiceConfig>(
+    service_config: &RwLock<T>,
+    endpoint_kwarg: Option<&str>,
+    region_kwarg: Option<&str>,
+    profile_kwarg: Option<&str>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    // Acquire locks and extract values, then drop locks immediately
+    let (endpoint_service, region_service, profile_service, region_global, profile_global) = {
+        let global = GLOBAL_CONFIG.read().unwrap();
+        let service = service_config.read().unwrap();
+
+        (
+            service.endpoint().clone(),
+            service.region().clone(),
+            service.profile().clone(),
+            global.region.clone(),
+            global.profile.clone(),
+        )
+        // Locks dropped here
+    };
+
+    // Apply precedence without holding any locks
+    let endpoint = endpoint_kwarg.map(String::from).or(endpoint_service);
+
+    let region = region_kwarg
+        .map(String::from)
+        .or(region_service)
+        .or(region_global);
+
+    let profile = profile_kwarg
+        .map(String::from)
+        .or(profile_service)
+        .or(profile_global);
+
+    (endpoint, region, profile)
+}
+
 /// Resolve S3 configuration with precedence.
 ///
 /// Precedence: kwargs > service config > global config
@@ -258,24 +354,7 @@ pub(crate) fn resolve_s3_config(
     region_kwarg: Option<&str>,
     profile_kwarg: Option<&str>,
 ) -> (Option<String>, Option<String>, Option<String>) {
-    let global = GLOBAL_CONFIG.read().unwrap();
-    let service = S3_CONFIG.read().unwrap();
-
-    let endpoint = endpoint_kwarg
-        .map(String::from)
-        .or_else(|| service.endpoint.clone());
-
-    let region = region_kwarg
-        .map(String::from)
-        .or_else(|| service.region.clone())
-        .or_else(|| global.region.clone());
-
-    let profile = profile_kwarg
-        .map(String::from)
-        .or_else(|| service.profile.clone())
-        .or_else(|| global.profile.clone());
-
-    (endpoint, region, profile)
+    resolve_config_with_precedence(&S3_CONFIG, endpoint_kwarg, region_kwarg, profile_kwarg)
 }
 
 /// Resolve SSM configuration with precedence.
@@ -286,24 +365,7 @@ pub(crate) fn resolve_ssm_config(
     region_kwarg: Option<&str>,
     profile_kwarg: Option<&str>,
 ) -> (Option<String>, Option<String>, Option<String>) {
-    let global = GLOBAL_CONFIG.read().unwrap();
-    let service = SSM_CONFIG.read().unwrap();
-
-    let endpoint = endpoint_kwarg
-        .map(String::from)
-        .or_else(|| service.endpoint.clone());
-
-    let region = region_kwarg
-        .map(String::from)
-        .or_else(|| service.region.clone())
-        .or_else(|| global.region.clone());
-
-    let profile = profile_kwarg
-        .map(String::from)
-        .or_else(|| service.profile.clone())
-        .or_else(|| global.profile.clone());
-
-    (endpoint, region, profile)
+    resolve_config_with_precedence(&SSM_CONFIG, endpoint_kwarg, region_kwarg, profile_kwarg)
 }
 
 /// Resolve CloudFormation configuration with precedence.
@@ -314,24 +376,7 @@ pub(crate) fn resolve_cfn_config(
     region_kwarg: Option<&str>,
     profile_kwarg: Option<&str>,
 ) -> (Option<String>, Option<String>, Option<String>) {
-    let global = GLOBAL_CONFIG.read().unwrap();
-    let service = CFN_CONFIG.read().unwrap();
-
-    let endpoint = endpoint_kwarg
-        .map(String::from)
-        .or_else(|| service.endpoint.clone());
-
-    let region = region_kwarg
-        .map(String::from)
-        .or_else(|| service.region.clone())
-        .or_else(|| global.region.clone());
-
-    let profile = profile_kwarg
-        .map(String::from)
-        .or_else(|| service.profile.clone())
-        .or_else(|| global.profile.clone());
-
-    (endpoint, region, profile)
+    resolve_config_with_precedence(&CFN_CONFIG, endpoint_kwarg, region_kwarg, profile_kwarg)
 }
 
 // =============================================================================
@@ -366,5 +411,238 @@ mod tests {
     fn test_register_all_doesnt_panic() {
         // Just verify registration doesn't panic
         register_all();
+    }
+
+    #[test]
+    fn test_s3_precedence_kwarg_over_service() {
+        // Setup
+        configure_s3(
+            Some("http://service-endpoint".to_string()),
+            Some("us-west-2".to_string()),
+            Some("service-profile".to_string()),
+        );
+
+        // Test: kwargs should override service config
+        let (endpoint, region, profile) = resolve_s3_config(
+            Some("http://kwarg-endpoint"),
+            Some("eu-west-1"),
+            Some("kwarg-profile"),
+        );
+
+        assert_eq!(endpoint, Some("http://kwarg-endpoint".to_string()));
+        assert_eq!(region, Some("eu-west-1".to_string()));
+        assert_eq!(profile, Some("kwarg-profile".to_string()));
+
+        // Cleanup
+        reset();
+    }
+
+    #[test]
+    fn test_s3_precedence_service_over_global() {
+        // Setup
+        configure(
+            Some("us-east-1".to_string()),
+            Some("global-profile".to_string()),
+        );
+        configure_s3(
+            None,
+            Some("us-west-2".to_string()),
+            Some("service-profile".to_string()),
+        );
+
+        // Test: service config should override global config
+        let (_, region, profile) = resolve_s3_config(None, None, None);
+
+        assert_eq!(region, Some("us-west-2".to_string()));
+        assert_eq!(profile, Some("service-profile".to_string()));
+
+        // Cleanup
+        reset();
+    }
+
+    #[test]
+    fn test_s3_precedence_global_fallback() {
+        // Setup
+        configure(
+            Some("us-east-1".to_string()),
+            Some("global-profile".to_string()),
+        );
+
+        // Test: global config used when no service or kwarg config
+        let (endpoint, region, profile) = resolve_s3_config(None, None, None);
+
+        assert_eq!(endpoint, None);
+        assert_eq!(region, Some("us-east-1".to_string()));
+        assert_eq!(profile, Some("global-profile".to_string()));
+
+        // Cleanup
+        reset();
+    }
+
+    #[test]
+    fn test_s3_precedence_partial_override() {
+        // Setup
+        configure(
+            Some("us-east-1".to_string()),
+            Some("global-profile".to_string()),
+        );
+        configure_s3(None, Some("us-west-2".to_string()), None);
+
+        // Test: partial override - region from service, profile from global
+        let (_, region, profile) = resolve_s3_config(None, None, None);
+
+        assert_eq!(region, Some("us-west-2".to_string()));
+        assert_eq!(profile, Some("global-profile".to_string()));
+
+        // Cleanup
+        reset();
+    }
+
+    #[test]
+    fn test_ssm_precedence_full_chain() {
+        // Setup: all three levels configured
+        configure(
+            Some("us-east-1".to_string()),
+            Some("global-profile".to_string()),
+        );
+        configure_ssm(
+            Some("http://service-endpoint".to_string()),
+            Some("us-west-2".to_string()),
+            Some("service-profile".to_string()),
+        );
+
+        // Test 1: kwarg overrides everything
+        let (endpoint, region, profile) = resolve_ssm_config(
+            Some("http://kwarg-endpoint"),
+            Some("eu-west-1"),
+            Some("kwarg-profile"),
+        );
+        assert_eq!(endpoint, Some("http://kwarg-endpoint".to_string()));
+        assert_eq!(region, Some("eu-west-1".to_string()));
+        assert_eq!(profile, Some("kwarg-profile".to_string()));
+
+        // Test 2: service overrides global
+        let (endpoint, region, profile) = resolve_ssm_config(None, None, None);
+        assert_eq!(endpoint, Some("http://service-endpoint".to_string()));
+        assert_eq!(region, Some("us-west-2".to_string()));
+        assert_eq!(profile, Some("service-profile".to_string()));
+
+        // Cleanup
+        reset();
+    }
+
+    #[test]
+    fn test_cfn_precedence_none_values_preserved() {
+        // Setup: configure only region at global level
+        configure(Some("us-east-1".to_string()), None);
+
+        // Test: None values remain None through all levels
+        let (endpoint, region, profile) = resolve_cfn_config(None, None, None);
+
+        assert_eq!(endpoint, None);
+        assert_eq!(region, Some("us-east-1".to_string()));
+        assert_eq!(profile, None);
+
+        // Cleanup
+        reset();
+    }
+
+    #[test]
+    fn test_reset_clears_all_config() {
+        // Setup: configure everything
+        configure(
+            Some("us-east-1".to_string()),
+            Some("global-profile".to_string()),
+        );
+        configure_s3(
+            Some("http://localhost:5000".to_string()),
+            Some("us-west-2".to_string()),
+            Some("s3-profile".to_string()),
+        );
+        configure_ssm(
+            Some("http://localhost:5001".to_string()),
+            Some("eu-west-1".to_string()),
+            None,
+        );
+        configure_cfn(None, None, Some("cfn-profile".to_string()));
+
+        // Test: reset clears everything
+        reset();
+
+        let (s3_endpoint, s3_region, s3_profile) = resolve_s3_config(None, None, None);
+        assert_eq!(s3_endpoint, None);
+        assert_eq!(s3_region, None);
+        assert_eq!(s3_profile, None);
+
+        let (ssm_endpoint, ssm_region, ssm_profile) = resolve_ssm_config(None, None, None);
+        assert_eq!(ssm_endpoint, None);
+        assert_eq!(ssm_region, None);
+        assert_eq!(ssm_profile, None);
+
+        let (cfn_endpoint, cfn_region, cfn_profile) = resolve_cfn_config(None, None, None);
+        assert_eq!(cfn_endpoint, None);
+        assert_eq!(cfn_region, None);
+        assert_eq!(cfn_profile, None);
+    }
+
+    #[test]
+    fn test_configure_none_leaves_unchanged() {
+        // Setup: initial configuration
+        configure(
+            Some("us-east-1".to_string()),
+            Some("initial-profile".to_string()),
+        );
+
+        // Test: calling with None leaves values unchanged
+        configure(None, None);
+
+        let (_, region, profile) = resolve_s3_config(None, None, None);
+        assert_eq!(region, Some("us-east-1".to_string()));
+        assert_eq!(profile, Some("initial-profile".to_string()));
+
+        // Cleanup
+        reset();
+    }
+
+    #[test]
+    fn test_service_config_none_leaves_unchanged() {
+        // Setup: initial service configuration
+        configure_s3(
+            Some("http://initial-endpoint".to_string()),
+            Some("us-west-2".to_string()),
+            Some("initial-profile".to_string()),
+        );
+
+        // Test: calling with None leaves values unchanged
+        configure_s3(None, None, None);
+
+        let (endpoint, region, profile) = resolve_s3_config(None, None, None);
+        assert_eq!(endpoint, Some("http://initial-endpoint".to_string()));
+        assert_eq!(region, Some("us-west-2".to_string()));
+        assert_eq!(profile, Some("initial-profile".to_string()));
+
+        // Cleanup
+        reset();
+    }
+
+    #[test]
+    fn test_service_config_partial_update() {
+        // Setup: initial service configuration
+        configure_s3(
+            Some("http://initial-endpoint".to_string()),
+            Some("us-west-2".to_string()),
+            Some("initial-profile".to_string()),
+        );
+
+        // Test: update only region, others remain unchanged
+        configure_s3(None, Some("eu-west-1".to_string()), None);
+
+        let (endpoint, region, profile) = resolve_s3_config(None, None, None);
+        assert_eq!(endpoint, Some("http://initial-endpoint".to_string()));
+        assert_eq!(region, Some("eu-west-1".to_string()));
+        assert_eq!(profile, Some("initial-profile".to_string()));
+
+        // Cleanup
+        reset();
     }
 }

--- a/crates/holoconf-aws/src/lib.rs
+++ b/crates/holoconf-aws/src/lib.rs
@@ -28,6 +28,9 @@
 //! config: ${s3:my-bucket/configs/app.yaml}
 //! ```
 
+use once_cell::sync::Lazy;
+use std::sync::RwLock;
+
 mod client_cache;
 
 #[cfg(feature = "ssm")]
@@ -47,6 +50,293 @@ pub use cfn::CfnResolver;
 
 #[cfg(feature = "s3")]
 pub use s3::S3Resolver;
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/// Global configuration (applies to all AWS services)
+#[derive(Clone, Default, Debug)]
+struct GlobalConfig {
+    region: Option<String>,
+    profile: Option<String>,
+}
+
+/// S3-specific configuration
+#[derive(Clone, Default, Debug)]
+pub struct S3Config {
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+    pub profile: Option<String>,
+}
+
+/// SSM-specific configuration
+#[derive(Clone, Default, Debug)]
+pub struct SsmConfig {
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+    pub profile: Option<String>,
+}
+
+/// CloudFormation-specific configuration
+#[derive(Clone, Default, Debug)]
+pub struct CfnConfig {
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+    pub profile: Option<String>,
+}
+
+static GLOBAL_CONFIG: Lazy<RwLock<GlobalConfig>> = Lazy::new(Default::default);
+static S3_CONFIG: Lazy<RwLock<S3Config>> = Lazy::new(Default::default);
+static SSM_CONFIG: Lazy<RwLock<SsmConfig>> = Lazy::new(Default::default);
+static CFN_CONFIG: Lazy<RwLock<CfnConfig>> = Lazy::new(Default::default);
+
+/// Configure global defaults for all AWS services.
+///
+/// Sets default region and profile for all AWS services (S3, SSM, CloudFormation).
+/// These can be overridden by service-specific configuration or per-resolver kwargs.
+///
+/// # Arguments
+///
+/// * `region` - Default AWS region
+/// * `profile` - Default AWS profile name
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use holoconf_aws;
+///
+/// // Set global defaults
+/// holoconf_aws::configure(Some("us-east-1".to_string()), Some("prod".to_string()));
+/// ```
+pub fn configure(region: Option<String>, profile: Option<String>) {
+    let mut config = GLOBAL_CONFIG.write().unwrap();
+    if let Some(r) = region {
+        config.region = Some(r);
+    }
+    if let Some(p) = profile {
+        config.profile = Some(p);
+    }
+}
+
+/// Configure S3-specific defaults.
+///
+/// Overrides global configuration for the S3 resolver.
+///
+/// # Arguments
+///
+/// * `endpoint` - S3 endpoint URL (for moto/LocalStack)
+/// * `region` - AWS region
+/// * `profile` - AWS profile name
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use holoconf_aws;
+///
+/// // Configure S3 for local testing
+/// holoconf_aws::configure_s3(
+///     Some("http://localhost:5000".to_string()),
+///     Some("us-west-2".to_string()),
+///     None,
+/// );
+/// ```
+pub fn configure_s3(endpoint: Option<String>, region: Option<String>, profile: Option<String>) {
+    let mut config = S3_CONFIG.write().unwrap();
+    if let Some(e) = endpoint {
+        config.endpoint = Some(e);
+    }
+    if let Some(r) = region {
+        config.region = Some(r);
+    }
+    if let Some(p) = profile {
+        config.profile = Some(p);
+    }
+}
+
+/// Configure SSM-specific defaults.
+///
+/// Overrides global configuration for the SSM resolver.
+///
+/// # Arguments
+///
+/// * `endpoint` - SSM endpoint URL (for moto/LocalStack)
+/// * `region` - AWS region
+/// * `profile` - AWS profile name
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use holoconf_aws;
+///
+/// // Configure SSM for local testing
+/// holoconf_aws::configure_ssm(
+///     Some("http://localhost:5001".to_string()),
+///     None,
+///     None,
+/// );
+/// ```
+pub fn configure_ssm(endpoint: Option<String>, region: Option<String>, profile: Option<String>) {
+    let mut config = SSM_CONFIG.write().unwrap();
+    if let Some(e) = endpoint {
+        config.endpoint = Some(e);
+    }
+    if let Some(r) = region {
+        config.region = Some(r);
+    }
+    if let Some(p) = profile {
+        config.profile = Some(p);
+    }
+}
+
+/// Configure CloudFormation-specific defaults.
+///
+/// Overrides global configuration for the CloudFormation resolver.
+///
+/// # Arguments
+///
+/// * `endpoint` - CloudFormation endpoint URL (for moto/LocalStack)
+/// * `region` - AWS region
+/// * `profile` - AWS profile name
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use holoconf_aws;
+///
+/// // Configure CloudFormation for local testing
+/// holoconf_aws::configure_cfn(
+///     Some("http://localhost:5002".to_string()),
+///     None,
+///     Some("testing".to_string()),
+/// );
+/// ```
+pub fn configure_cfn(endpoint: Option<String>, region: Option<String>, profile: Option<String>) {
+    let mut config = CFN_CONFIG.write().unwrap();
+    if let Some(e) = endpoint {
+        config.endpoint = Some(e);
+    }
+    if let Some(r) = region {
+        config.region = Some(r);
+    }
+    if let Some(p) = profile {
+        config.profile = Some(p);
+    }
+}
+
+/// Reset all configuration and clear the client cache.
+///
+/// Clears all global and service-specific configuration, and removes all cached AWS clients.
+/// Useful for test isolation.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use holoconf_aws;
+///
+/// // Configure for testing
+/// holoconf_aws::configure_s3(Some("http://localhost:5000".to_string()), None, None);
+///
+/// // Run tests...
+///
+/// // Reset for next test
+/// holoconf_aws::reset();
+/// ```
+pub fn reset() {
+    *GLOBAL_CONFIG.write().unwrap() = Default::default();
+    *S3_CONFIG.write().unwrap() = Default::default();
+    *SSM_CONFIG.write().unwrap() = Default::default();
+    *CFN_CONFIG.write().unwrap() = Default::default();
+    client_cache::clear();
+}
+
+/// Resolve S3 configuration with precedence.
+///
+/// Precedence: kwargs > service config > global config
+pub(crate) fn resolve_s3_config(
+    endpoint_kwarg: Option<&str>,
+    region_kwarg: Option<&str>,
+    profile_kwarg: Option<&str>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let global = GLOBAL_CONFIG.read().unwrap();
+    let service = S3_CONFIG.read().unwrap();
+
+    let endpoint = endpoint_kwarg
+        .map(String::from)
+        .or_else(|| service.endpoint.clone());
+
+    let region = region_kwarg
+        .map(String::from)
+        .or_else(|| service.region.clone())
+        .or_else(|| global.region.clone());
+
+    let profile = profile_kwarg
+        .map(String::from)
+        .or_else(|| service.profile.clone())
+        .or_else(|| global.profile.clone());
+
+    (endpoint, region, profile)
+}
+
+/// Resolve SSM configuration with precedence.
+///
+/// Precedence: kwargs > service config > global config
+pub(crate) fn resolve_ssm_config(
+    endpoint_kwarg: Option<&str>,
+    region_kwarg: Option<&str>,
+    profile_kwarg: Option<&str>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let global = GLOBAL_CONFIG.read().unwrap();
+    let service = SSM_CONFIG.read().unwrap();
+
+    let endpoint = endpoint_kwarg
+        .map(String::from)
+        .or_else(|| service.endpoint.clone());
+
+    let region = region_kwarg
+        .map(String::from)
+        .or_else(|| service.region.clone())
+        .or_else(|| global.region.clone());
+
+    let profile = profile_kwarg
+        .map(String::from)
+        .or_else(|| service.profile.clone())
+        .or_else(|| global.profile.clone());
+
+    (endpoint, region, profile)
+}
+
+/// Resolve CloudFormation configuration with precedence.
+///
+/// Precedence: kwargs > service config > global config
+pub(crate) fn resolve_cfn_config(
+    endpoint_kwarg: Option<&str>,
+    region_kwarg: Option<&str>,
+    profile_kwarg: Option<&str>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let global = GLOBAL_CONFIG.read().unwrap();
+    let service = CFN_CONFIG.read().unwrap();
+
+    let endpoint = endpoint_kwarg
+        .map(String::from)
+        .or_else(|| service.endpoint.clone());
+
+    let region = region_kwarg
+        .map(String::from)
+        .or_else(|| service.region.clone())
+        .or_else(|| global.region.clone());
+
+    let profile = profile_kwarg
+        .map(String::from)
+        .or_else(|| service.profile.clone())
+        .or_else(|| global.profile.clone());
+
+    (endpoint, region, profile)
+}
+
+// =============================================================================
+// Registration
+// =============================================================================
 
 /// Register all AWS resolvers in the global registry.
 ///

--- a/docs/specs/features/FEAT-007-aws-resolvers.md
+++ b/docs/specs/features/FEAT-007-aws-resolvers.md
@@ -347,6 +347,7 @@ AWS resolvers support two levels of configuration for testing and advanced use c
 
 Set default region and profile for all AWS services:
 
+**Python:**
 ```python
 import holoconf_aws
 
@@ -357,12 +358,24 @@ holoconf_aws.configure(
 )
 ```
 
+**Rust:**
+```rust
+use holoconf_aws;
+
+// Configure defaults for all AWS services
+holoconf_aws::configure(
+    Some("us-east-1".to_string()),    // Default region
+    Some("prod".to_string()),          // Default AWS profile
+);
+```
+
 **Note:** Global configuration only supports `region` and `profile`. Endpoints are service-specific (see below).
 
 ### Service-Specific Configuration
 
 Override defaults for individual services, including endpoints:
 
+**Python:**
 ```python
 # S3-specific configuration
 holoconf_aws.s3(
@@ -382,12 +395,44 @@ holoconf_aws.cfn(
 )
 ```
 
+**Rust:**
+```rust
+use holoconf_aws;
+
+// S3-specific configuration
+holoconf_aws::configure_s3(
+    Some("http://localhost:5000".to_string()),  // For moto/LocalStack
+    Some("us-west-2".to_string()),              // Override global region
+    Some("dev".to_string()),                    // Override global profile
+);
+
+// SSM-specific configuration
+holoconf_aws::configure_ssm(
+    Some("http://localhost:5001".to_string()),
+    None,
+    None,
+);
+
+// CloudFormation-specific configuration
+holoconf_aws::configure_cfn(
+    None,
+    None,
+    Some("testing".to_string()),
+);
+```
+
 ### Reset Configuration
 
 Clear all configuration and client cache:
 
+**Python:**
 ```python
 holoconf_aws.reset()
+```
+
+**Rust:**
+```rust
+holoconf_aws::reset();
 ```
 
 ### Precedence
@@ -400,6 +445,8 @@ Configuration follows this precedence chain (highest to lowest):
 4. **AWS SDK defaults** - Environment variables, credentials file, IMDS
 
 **Example:**
+
+**Python:**
 ```python
 # Set global default
 holoconf_aws.configure(region="us-east-1")
@@ -407,6 +454,17 @@ holoconf_aws.configure(region="us-east-1")
 # Override for S3
 holoconf_aws.s3(region="us-west-2")
 ```
+
+**Rust:**
+```rust
+// Set global default
+holoconf_aws::configure(Some("us-east-1".to_string()), None);
+
+// Override for S3
+holoconf_aws::configure_s3(None, Some("us-west-2".to_string()), None);
+```
+
+**Configuration file (applies to both Python and Rust):**
 ```yaml
 # Uses us-west-2 (service config)
 s3_value: ${s3:bucket/file}

--- a/packages/python/holoconf-aws/src/holoconf_aws/__init__.py
+++ b/packages/python/holoconf-aws/src/holoconf_aws/__init__.py
@@ -28,7 +28,35 @@ The `s3` resolver fetches objects from Amazon S3.
 config: ${s3:my-bucket/configs/app.yaml}
 ```
 
-### Setup
+## Configuration API
+
+Configure AWS client defaults for testing with moto/LocalStack and advanced use cases:
+
+```python
+import holoconf_aws
+
+# Global configuration (applies to all AWS services)
+holoconf_aws.configure(region="us-east-1", profile="prod")
+
+# Service-specific configuration (overrides global defaults)
+holoconf_aws.s3(endpoint="http://localhost:5000", region="us-west-2")
+holoconf_aws.ssm(endpoint="http://localhost:5001")
+holoconf_aws.cfn(profile="testing")
+
+# Reset all configuration and clear client cache
+holoconf_aws.reset()
+```
+
+Configuration precedence (highest to lowest):
+1. Resolver kwargs in config file (e.g., `${s3:bucket/file,region=us-east-1}`)
+2. Service-specific configuration (`holoconf_aws.s3()`, `ssm()`, `cfn()`)
+3. Global configuration (`holoconf_aws.configure()`)
+4. AWS SDK defaults (environment variables, credentials file)
+
+Calling configuration functions with `None` leaves existing values unchanged.
+Use `reset()` to clear all configuration for test isolation.
+
+## Setup
 
 AWS resolvers are automatically registered when holoconf is imported, via
 entry point discovery. Just install holoconf-aws and the resolvers become
@@ -50,6 +78,26 @@ register_s3()
 ```
 """
 
-from holoconf_aws._holoconf_aws import register_all, register_cfn, register_s3, register_ssm
+from holoconf_aws._holoconf_aws import (
+    cfn,
+    configure,
+    register_all,
+    register_cfn,
+    register_s3,
+    register_ssm,
+    reset,
+    s3,
+    ssm,
+)
 
-__all__ = ["register_all", "register_cfn", "register_s3", "register_ssm"]
+__all__ = [
+    "cfn",
+    "configure",
+    "register_all",
+    "register_cfn",
+    "register_s3",
+    "register_ssm",
+    "reset",
+    "s3",
+    "ssm",
+]

--- a/packages/python/holoconf-aws/src/holoconf_aws/_holoconf_aws.pyi
+++ b/packages/python/holoconf-aws/src/holoconf_aws/_holoconf_aws.pyi
@@ -46,3 +46,102 @@ def register_all(force: bool = False) -> None:
                If False (default), only register if not already registered.
     """
     ...
+
+def configure(region: str | None = None, profile: str | None = None) -> None:
+    """Configure global defaults for all AWS services.
+
+    Sets default region and profile that apply to all AWS services (S3, SSM, CloudFormation).
+    These can be overridden by service-specific configuration or per-resolver kwargs.
+
+    Configuration precedence (highest to lowest):
+    1. Resolver kwargs in config file (e.g., ${s3:bucket/file,region=us-east-1})
+    2. Service-specific configuration (holoconf_aws.s3(), ssm(), cfn())
+    3. Global configuration (holoconf_aws.configure())
+    4. AWS SDK defaults (environment variables, credentials file)
+
+    Args:
+        region: Default AWS region (e.g., "us-east-1"). Pass None to leave unchanged.
+        profile: Default AWS profile name. Pass None to leave unchanged.
+
+    Example:
+        >>> import holoconf_aws
+        >>> holoconf_aws.configure(region="us-east-1", profile="prod")
+    """
+    ...
+
+def s3(
+    endpoint: str | None = None,
+    region: str | None = None,
+    profile: str | None = None,
+) -> None:
+    """Configure S3-specific defaults.
+
+    Overrides global configuration for the S3 resolver.
+
+    Args:
+        endpoint: S3 endpoint URL (for moto/LocalStack, e.g., "http://localhost:5000").
+                  Pass None to leave unchanged.
+        region: AWS region (overrides global region). Pass None to leave unchanged.
+        profile: AWS profile name (overrides global profile). Pass None to leave unchanged.
+
+    Example:
+        >>> import holoconf_aws
+        >>> holoconf_aws.s3(endpoint="http://localhost:5000", region="us-west-2")
+    """
+    ...
+
+def ssm(
+    endpoint: str | None = None,
+    region: str | None = None,
+    profile: str | None = None,
+) -> None:
+    """Configure SSM-specific defaults.
+
+    Overrides global configuration for the SSM resolver.
+
+    Args:
+        endpoint: SSM endpoint URL (for moto/LocalStack, e.g., "http://localhost:5001").
+                  Pass None to leave unchanged.
+        region: AWS region (overrides global region). Pass None to leave unchanged.
+        profile: AWS profile name (overrides global profile). Pass None to leave unchanged.
+
+    Example:
+        >>> import holoconf_aws
+        >>> holoconf_aws.ssm(endpoint="http://localhost:5001")
+    """
+    ...
+
+def cfn(
+    endpoint: str | None = None,
+    region: str | None = None,
+    profile: str | None = None,
+) -> None:
+    """Configure CloudFormation-specific defaults.
+
+    Overrides global configuration for the CloudFormation resolver.
+
+    Args:
+        endpoint: CloudFormation endpoint URL (for moto/LocalStack, e.g., "http://localhost:5002").
+                  Pass None to leave unchanged.
+        region: AWS region (overrides global region). Pass None to leave unchanged.
+        profile: AWS profile name (overrides global profile). Pass None to leave unchanged.
+
+    Example:
+        >>> import holoconf_aws
+        >>> holoconf_aws.cfn(profile="testing")
+    """
+    ...
+
+def reset() -> None:
+    """Reset all configuration and clear the client cache.
+
+    Clears all global and service-specific configuration, and removes all cached AWS clients.
+    Useful for test isolation.
+
+    Example:
+        >>> import holoconf_aws
+        >>> holoconf_aws.s3(endpoint="http://localhost:5000")
+        >>> # ... run tests ...
+        >>> holoconf_aws.reset()  # Clean up for next test
+    """
+    ...


### PR DESCRIPTION
## Summary

Implements a two-tier configuration system for AWS resolvers to support testing with moto/LocalStack and advanced configuration scenarios. Global `configure(region, profile)` applies to all services, while service-specific functions `s3()`, `ssm()`, `cfn()` allow per-service overrides including endpoint URLs. Supports three-level precedence: resolver kwargs > service config > global config > AWS SDK defaults.

## Related Issue

Closes #27

## Spec / ADR

**Related specs:** FEAT-007

- [x] Specs consulted before implementation
- [x] Specs created/updated if new behavior
- [x] Implementation matches spec requirements

Updated [FEAT-007: AWS Resolvers](docs/specs/features/FEAT-007-aws-resolvers.md) to document the two-tier configuration API with precedence rules and use cases.

## Changes

- [x] Rust core (`crates/holoconf-aws/`)
- [x] Python bindings (`crates/holoconf-aws-python/`)
- [ ] CLI (`crates/holoconf-cli/`)
- [x] Documentation (`docs/`)
- [x] Tests

## Checklist

- [x] `make check` passes
- [x] Added/updated tests (all 27 AWS unit tests passing)
- [ ] Updated CHANGELOG.md (if user-facing)
- [ ] Updated type stubs (if Python API changed)
- [x] Updated docs (if user-facing)

## Implementation Details

### API

**Python:**
\`\`\`python
import holoconf_aws

# Global defaults (all services)
holoconf_aws.configure(region="us-east-1", profile="prod")

# Service-specific (includes endpoint)
holoconf_aws.s3(endpoint="http://localhost:5000", region="us-west-2")
holoconf_aws.ssm(endpoint="http://localhost:5001")
holoconf_aws.cfn(profile="testing")

# Reset all configuration + client cache
holoconf_aws.reset()
\`\`\`

**Rust:**
\`\`\`rust
use holoconf_aws;

holoconf_aws::configure(Some("us-east-1".to_string()), Some("prod".to_string()));
holoconf_aws::configure_s3(Some("http://localhost:5000".to_string()), None, None);
holoconf_aws::reset();
\`\`\`

**Resolver kwargs:**
\`\`\`yaml
value: \${s3:bucket/file,endpoint=http://localhost:5000,region=eu-west-1}
\`\`\`

### Technical Changes

- Added global configuration storage per service (RwLock-protected)
- Updated client cache to include endpoint in cache key
- Updated all resolvers (S3, SSM, CFN) to merge kwargs with config using precedence chain
- Added `clear()` function to client cache for `reset()`
- Added `endpoint=` kwarg support to all AWS resolvers
- Exposed configuration functions through Python bindings

### Testing

All 27 AWS unit tests pass, including new tests for client cache with endpoints.